### PR TITLE
Release v0.5.4

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.5.4 — 2022-08-19
+
+This version contains minor improvements:
+
+1. Improve typechecking by trying an easier unification strategy first (see [#76](https://github.com/rzk-lang/rzk/pull/76));
+2. Update GitHub Action for Nix (see [#74](https://github.com/rzk-lang/rzk/pull/74)).
+
 ## v0.5.3 — 2022-07-12
 
 This version contains a few minor improvements:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.5.3
+version: 0.5.4
 github: "rzk-lang/rzk"
 license: BSD3
 author: "Nikolai Kudasov"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.5.3
+version:        0.5.4
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types

--- a/rzk/rzk.nix
+++ b/rzk/rzk.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "rzk";
-  version = "0.5.3";
+  version = "0.5.4";
   src = ./.;
   isLibrary = true;
   isExecutable = true;


### PR DESCRIPTION
This version contains minor improvements:

1. Improve typechecking by trying an easier unification strategy first (see [#76](https://github.com/rzk-lang/rzk/pull/76));
2. Update GitHub Action for Nix (see [#74](https://github.com/rzk-lang/rzk/pull/74)).
