### PR TITLE
Install and use the glob package

### DIFF
--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -32,6 +32,7 @@ dependencies:
   - template-haskell
   - text
   - optparse-generic
+  - Glob
 
 ghc-options:
   - -Wall

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -50,7 +50,8 @@ library
       alex
     , happy
   build-depends:
-      aeson
+      Glob
+    , aeson
     , array
     , base >=4.7 && <5
     , bifunctors
@@ -72,7 +73,8 @@ executable rzk
       alex
     , happy
   build-depends:
-      aeson
+      Glob
+    , aeson
     , array
     , base >=4.7 && <5
     , bifunctors
@@ -123,7 +125,8 @@ test-suite rzk-test
       alex
     , happy
   build-depends:
-      aeson
+      Glob
+    , aeson
     , array
     , base >=4.7 && <5
     , bifunctors

--- a/rzk/rzk.nix
+++ b/rzk/rzk.nix
@@ -7,18 +7,23 @@ mkDerivation {
   version = "0.5.4";
   src = ./.;
   isLibrary = true;
-  isExecutable = false;
+  isExecutable = true;
   libraryHaskellDepends = [
-    aeson array base bifunctors bytestring mtl optparse-generic
+    aeson array base bifunctors bytestring Glob mtl optparse-generic
     template-haskell text
   ];
   libraryToolDepends = [ alex happy hpack ];
+  executableHaskellDepends = [
+    aeson array base bifunctors bytestring Glob mtl optparse-generic
+    template-haskell text
+  ];
+  executableToolDepends = [ alex happy ];
   testHaskellDepends = [
     aeson array base bifunctors bytestring doctest Glob mtl
     optparse-generic QuickCheck template-haskell text
   ];
   testToolDepends = [ alex happy ];
-  /* prePatch = "hpack"; */
+  prePatch = "hpack";
   homepage = "https://github.com/rzk-lang/rzk#readme";
   description = "An experimental proof assistant for synthetic ∞-categories";
   license = lib.licenses.bsd3;

--- a/rzk/src/Rzk/Main.hs
+++ b/rzk/src/Rzk/Main.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString.Lazy.Char8   as ByteString
 import           Data.Version                 (showVersion)
 import           Options.Generic
 import           System.Exit                  (exitFailure)
+import           System.FilePath.Glob         (glob)
 
 import qualified Language.Rzk.Syntax          as Rzk
 import           Language.Rzk.VSCode.Tokenize (tokenizeModule)
@@ -58,14 +59,16 @@ parseRzkFilesOrStdin = \case
     rzkModule <- parseStdin
     return [("<stdin>", rzkModule)]
   -- otherwise — parse all given files in given order
-  paths -> forM paths $ \path -> do
-    putStrLn ("Loading file " <> path)
-    result <- Rzk.parseModule <$> readFile path
-    case result of
-      Left err -> do
-        putStrLn ("An error occurred when parsing file " <> path)
-        error err
-      Right rzkModule -> return (path, rzkModule)
+  paths -> do
+    expandedPaths <- foldMap glob paths
+    forM (reverse expandedPaths) $ \path -> do
+      putStrLn ("Loading file " <> path)
+      result <- Rzk.parseModule <$> readFile path
+      case result of
+        Left err -> do
+          putStrLn ("An error occurred when parsing file " <> path)
+          error err
+        Right rzkModule -> return (path, rzkModule)
 
 typecheckString :: String -> Either String String
 typecheckString moduleString = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,7 @@ packages:
 #
 extra-deps:
 - with-utf8-1.0.2.4
+- Glob-0.10.2
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       size: 1051
   original:
     hackage: with-utf8-1.0.2.4
+- completed:
+    hackage: Glob-0.10.2@sha256:dd2ddbecae8f84e8f4cacb5b856901a19c25ceaa11f2525d3ee88d034acb0081,2938
+    pantry-tree:
+      sha256: 3c9d365a19c0e15d7cf5e93ee994bdc81958c8e4056f43ec0408f34f1a3bb970
+      size: 1432
+  original:
+    hackage: Glob-0.10.2
 snapshots:
 - completed:
     sha256: cbf721fafa21237e4999d83cfd27137f440ae0e3032ff18fa96e8148d9bf5ce1


### PR DESCRIPTION
To improve support for shells that do not expand globs automatically
such as PowerShell and CMD on Windows