### PR TITLE
Text completions

### DIFF
--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -37,6 +37,7 @@ dependencies:
   - filepath
   - stm
   - yaml
+  - data-default-class
 
 ghc-options:
   - -Wall

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -54,6 +54,7 @@ library
     , base >=4.7 && <5
     , bifunctors
     , bytestring
+    , data-default-class
     , filepath
     , lens
     , mtl
@@ -91,6 +92,7 @@ executable rzk
     , base >=4.7 && <5
     , bifunctors
     , bytestring
+    , data-default-class
     , filepath
     , lens
     , mtl
@@ -122,6 +124,7 @@ test-suite doctests
     , base
     , bifunctors
     , bytestring
+    , data-default-class
     , doctest
     , filepath
     , lens
@@ -151,6 +154,7 @@ test-suite rzk-test
     , base >=4.7 && <5
     , bifunctors
     , bytestring
+    , data-default-class
     , filepath
     , lens
     , mtl

--- a/rzk/rzk.nix
+++ b/rzk/rzk.nix
@@ -1,6 +1,7 @@
 { mkDerivation, aeson, alex, array, base, bifunctors, bytestring
-, doctest, filepath, Glob, happy, hpack, lens, lib, mtl
-, optparse-generic, QuickCheck, stm, template-haskell, text, yaml
+, data-default-class, doctest, filepath, Glob, happy, hpack, lens
+, lib, mtl, optparse-generic, QuickCheck, stm, template-haskell
+, text, yaml
 }:
 mkDerivation {
   pname = "rzk";
@@ -9,18 +10,19 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson array base bifunctors bytestring filepath Glob lens mtl
-    optparse-generic stm template-haskell text yaml
+    aeson array base bifunctors bytestring data-default-class filepath
+    Glob lens mtl optparse-generic stm template-haskell text yaml
   ];
   libraryToolDepends = [ alex happy hpack ];
   executableHaskellDepends = [
-    aeson array base bifunctors bytestring filepath Glob lens mtl
-    optparse-generic stm template-haskell text yaml
+    aeson array base bifunctors bytestring data-default-class filepath
+    Glob lens mtl optparse-generic stm template-haskell text yaml
   ];
   executableToolDepends = [ alex happy ];
   testHaskellDepends = [
-    aeson array base bifunctors bytestring doctest filepath Glob lens
-    mtl optparse-generic QuickCheck stm template-haskell text yaml
+    aeson array base bifunctors bytestring data-default-class doctest
+    filepath Glob lens mtl optparse-generic QuickCheck stm
+    template-haskell text yaml
   ];
   testToolDepends = [ alex happy ];
   prePatch = "hpack";

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Rzk.VSCode.Handlers where
 
@@ -142,3 +143,8 @@ typecheckFromConfigFile = do
                       Nothing
                       (Just [])
                       Nothing
+
+instance Default T.Text where def = ""
+instance Default CompletionItem
+instance Default CompletionItemLabelDetails
+

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -6,20 +7,30 @@
 module Language.Rzk.VSCode.Handlers where
 
 import           Control.Exception             (SomeException, evaluate, try)
+import           Control.Lens
 import           Control.Monad.Cont            (MonadIO (liftIO), forM_)
+import           Data.Default.Class
 import           Data.List                     (sort, (\\))
+import           Data.Maybe                    (fromMaybe)
 import qualified Data.Text                     as T
 import qualified Data.Yaml                     as Yaml
 import           Language.LSP.Diagnostics      (partitionBySource)
+import           Language.LSP.Protocol.Lens    (HasDetail (detail),
+                                                HasDocumentation (documentation),
+                                                HasLabel (label),
+                                                HasParams (params),
+                                                HasTextDocument (textDocument),
+                                                HasUri (uri))
 import           Language.LSP.Protocol.Message
 import           Language.LSP.Protocol.Types
 import           Language.LSP.Server
-import           System.FilePath               ((</>))
+import           System.FilePath               (makeRelative, (</>))
 import           System.FilePath.Glob          (compile, globDir)
 
-import           Data.Maybe                    (fromMaybe)
-import           Language.Rzk.Free.Syntax      (VarIdent)
-import           Language.Rzk.Syntax           (Module, parseModuleFile)
+import           Language.Rzk.Free.Syntax      (RzkPosition (RzkPosition),
+                                                VarIdent (getVarIdent))
+import           Language.Rzk.Syntax           (Module, VarIdent' (VarIdent),
+                                                parseModuleFile, printTree)
 import           Language.Rzk.VSCode.Env
 import           Language.Rzk.VSCode.State     (ProjectConfig (include))
 import           Rzk.TypeCheck
@@ -148,3 +159,35 @@ instance Default T.Text where def = ""
 instance Default CompletionItem
 instance Default CompletionItemLabelDetails
 
+provideCompletions :: Handler LSP 'Method_TextDocumentCompletion
+provideCompletions req res = do
+  root <- getRootPath
+  let rootDir = fromMaybe "/" root
+  cachedModules <- getCachedTypecheckedModules
+  let currentFile = fromMaybe "" $ uriToFilePath $ req ^. params . textDocument . uri
+  -- Take all the modules up to and including the currently open one
+  let modules = takeWhileInc ((/= currentFile) . fst) cachedModules
+        where
+          takeWhileInc _ [] = []
+          takeWhileInc p (x:xs)
+            | p x       = x : takeWhileInc p xs
+            | otherwise = [x]
+
+  let items = concatMap (declsToItems rootDir) modules
+  res $ Right $ InL items
+  where
+    declsToItems :: FilePath -> (FilePath, [Decl']) -> [CompletionItem]
+    declsToItems root (path, decls) = map (declToItem root path) decls
+    declToItem :: FilePath -> FilePath -> Decl' -> CompletionItem
+    declToItem rootDir path (Decl name type' _ _ _) = def
+      & label .~ T.pack (printTree $ getVarIdent name)
+      & detail ?~ T.pack (show type')
+      & documentation ?~ InR (MarkupContent MarkupKind_Markdown $ T.pack $
+          "---\nDefined" ++
+          (if line > 0 then " at line " ++ show line else "")
+          ++ " in *" ++ makeRelative rootDir path ++ "*")
+      where
+        (VarIdent pos _) = getVarIdent name
+        (RzkPosition _path pos') = pos
+        line = maybe 0 fst pos'
+        _col = maybe 0 snd pos'

--- a/rzk/src/Language/Rzk/VSCode/Lsp.hs
+++ b/rzk/src/Language/Rzk/VSCode/Lsp.hs
@@ -58,6 +58,7 @@ handlers =
     --         ms = mkMarkdown "Hello world"
     --         range' = Range pos pos
     --     responder (Right $ InL rsp)
+    , requestHandler SMethod_TextDocumentCompletion provideCompletions
     , requestHandler SMethod_TextDocumentSemanticTokensFull $ \req responder -> do
         let doc = req ^. params . textDocument . uri . to toNormalizedUri
         mdoc <- getVirtualFile doc

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,6 +48,7 @@ extra-deps:
   - row-types-1.0.1.2
   - filepath-1.4.2.2
   - yaml-0.11.11.2
+  - data-default-class-0.1.2.0
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -60,6 +60,13 @@ packages:
       size: 2044
   original:
     hackage: yaml-0.11.11.2
+- completed:
+    hackage: data-default-class-0.1.2.0@sha256:63e62120b7efd733a5a17cf59ceb43268e9a929c748127172d7d42f4a336e327,542
+    pantry-tree:
+      sha256: 5017630b11698aefa65fc61cab84a257ce97833c968d425e1b2d53d6c3b5c096
+      size: 224
+  original:
+    hackage: data-default-class-0.1.2.0
 snapshots:
 - completed:
     sha256: cbf721fafa21237e4999d83cfd27137f440ae0e3032ff18fa96e8148d9bf5ce1


### PR DESCRIPTION
Uses the previously declared symbols in all previous files (and the currently open one) to provide a list of completion items, displaying their type and definition location.

![image](https://github.com/rzk-lang/rzk/assets/11016151/c6776393-6a2b-47b2-b6dd-dd08bc8d3c9a)

One known caveat for now is that if there is an error in the current file (e.g.: in the process of defining something), previous  declarations in the same file will not show up. This is a known imperfection in the incremental type checker itself