### PR TITLE
Improve order of information in error messages for LSP

### DIFF
--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -121,7 +121,7 @@ typecheckFromConfigFile = do
                       (Just [])                 -- related information
                       Nothing                   -- data that is preserved between different calls
       where
-        msg = ppTypeErrorInScopedContext' err
+        msg = ppTypeErrorInScopedContext' TopDown err
 
         extractLineNumber :: TypeErrorInScopedContext var -> Maybe Int
         extractLineNumber (PlainTypeError e)    = do

--- a/rzk/src/Rzk/Main.hs
+++ b/rzk/src/Rzk/Main.hs
@@ -35,7 +35,7 @@ main = getRecord "rzk: an experimental proof assistant for synthetic ∞-categor
         putStrLn "An error occurred when typechecking!"
         putStrLn $ unlines
           [ "Type Error:"
-          , ppTypeErrorInScopedContext' err
+          , ppTypeErrorInScopedContext' BottomUp err
           ]
         exitFailure
       Right _declsByPath -> putStrLn "Everything is ok!"
@@ -93,7 +93,7 @@ typecheckString moduleString = do
       , "Rendering type error... (this may take a few seconds)"
       , unlines
         [ "Type Error:"
-        , ppTypeErrorInScopedContext' err
+        , ppTypeErrorInScopedContext' BottomUp err
         ]
       ]
     Right _ -> pure "Everything is ok!"


### PR DESCRIPTION
Now the actual error message is on top, so there is no need to scroll:

<img width="1019" alt="Screenshot 2023-09-26 at 06 38 33" src="https://github.com/rzk-lang/rzk/assets/686582/b6613e79-10f4-4e0a-aa4b-f6d078c7e2c1">
