### PR TITLE
Release v0.6.3

### DIFF
--- a/docs/docs/getting-started/changelog.md
+++ b/docs/docs/getting-started/changelog.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.3 — 2023-09-27
+
+This version contains a fix for the command line interface of `rzk`:
+
+- Fix command line `rzk typecheck` (see [#106](https://github.com/rzk-lang/rzk/pull/106))
+
+  - Previous version ignored failures in the command line
+    (the bug was introced when allowing better autocompletion in LSP).
+
 ## v0.6.2 — 2023-09-26
 
 This version contains some improvements in efficiency and also to the language server:

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.3 — 2023-09-27
+
+This version contains a fix for the command line interface of `rzk`:
+
+- Fix command line `rzk typecheck` (see [#106](https://github.com/rzk-lang/rzk/pull/106))
+
+  - Previous version ignored failures in the command line
+    (the bug was introced when allowing better autocompletion in LSP).
+
 ## v0.6.2 — 2023-09-26
 
 This version contains some improvements in efficiency and also to the language server:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.6.2
+version: 0.6.3
 github: 'rzk-lang/rzk'
 license: BSD3
 author: 'Nikolai Kudasov'

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.6.2
+version:        0.6.3
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types

--- a/rzk/rzk.nix
+++ b/rzk/rzk.nix
@@ -5,7 +5,7 @@
 }:
 mkDerivation {
   pname = "rzk";
-  version = "0.6.2";
+  version = "0.6.3";
   src = ./.;
   isLibrary = true;
   isExecutable = true;


### PR DESCRIPTION
This version contains a fix for the command line interface of `rzk`:

- Fix command line `rzk typecheck` (see [#106](https://github.com/rzk-lang/rzk/pull/106))

  - Previous version ignored failures in the command line
    (the bug was introced when allowing better autocompletion in LSP).