### PR TITLE
Fix snippet param in the Rzk Playground

### DIFF
--- a/try-rzk/index.html
+++ b/try-rzk/index.html
@@ -315,6 +315,7 @@
       /* use default snippet if one is not set in the query parameters */
       if (params.has("snippet")) {
         snippet = decodeURIComponent(params.get("snippet"));
+        myCodeMirror.setValue(snippet);
       } else if (params.has("snippet_url")) {
         snippet_url = decodeURIComponent(params.get("snippet_url"));
         fetch(snippet_url).then(function (response) {


### PR DESCRIPTION
With this fix the following template works for playground:

```
https://rzk-lang.github.io/rzk/v0.6.4/playground/?snippet={code}
```

For some reason, the version has to be spelled out (`latest` does not redirect correctly).