### PR TITLE
fix: stack setup and caching

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,7 +30,6 @@ jobs:
       - name: 🧰 Setup Stack
         uses: freckle/stack-action@v4
         with:
-          cache-prefix: ${{ runner.os }}-stack-
           pedantic: false
 
       - name: 🔨 Install BNFC, alex and happy (with Stack)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,6 +31,7 @@ jobs:
         uses: freckle/stack-action@v4
         with:
           cache-prefix: ${{ runner.os }}-stack-
+          pedantic: false
 
       - name: 🔨 Install BNFC, alex and happy (with Stack)
         run: |


### PR DESCRIPTION
I removed the prefix because it turned out the `stack-action` already gives a meaningful name to caches.

I disabled `pedantic: true` (== `Werror`) to prevent failures on warnings ([link](https://github.com/rzk-lang/rzk/actions/runs/6367305086/job/17285760324#step:3:5045)).