### PR TITLE
Release v0.6.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,5 +4,5 @@ authors:
   given-names: Nikolai
   orcid: "https://orcid.org/0000-0001-6572-7292"
 title: "Rzk: a  proof assistant for synthetic $\\infty$-categories"
-version: 0.5.2
+version: 0.6.5
 url: "https://github.com/rzk-lang/rzk"

--- a/docs/docs/getting-started/changelog.md
+++ b/docs/docs/getting-started/changelog.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.5 — 2023-10-01
+
+This version contains mostly intrastructure improvements:
+
+- Typecheck using `rzk.yaml` if it exists (see [#119](https://github.com/rzk-lang/rzk/pull/119))
+- Update Rzk Playground and Nix Flake (see [#84](https://github.com/rzk-lang/rzk/pull/84))
+  - Rzk Playground now uses CodeMirror 6 and NextJS
+  - `miso` dependency is dropped
+  - GHCJS 9.6 is now used
+  - Support `snippet={code}` or `code={code}` param (see [#118](https://github.com/rzk-lang/rzk/pull/118))
+    - Support for `snippet_url={URL}` is temporarily dropped
+- Update to GHC 9.6, latest Stackage Nightly, improve Rzk setup, and GitHub Actions (see [#116](https://github.com/rzk-lang/rzk/pull/116))
+- Add logging for Rzk Language Server (see [#114](https://github.com/rzk-lang/rzk/pull/114))
+
+Fixes:
+
+- Fix error messages in Rzk Playground (see [#115](https://github.com/rzk-lang/rzk/pull/115))
+
 ## v0.6.4 — 2023-09-27
 
 This version improves the stucture of the project, in particular w.r.t dependencies:

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.5 — 2023-10-01
+
+This version contains mostly intrastructure improvements:
+
+- Typecheck using `rzk.yaml` if it exists (see [#119](https://github.com/rzk-lang/rzk/pull/119))
+- Update Rzk Playground and Nix Flake (see [#84](https://github.com/rzk-lang/rzk/pull/84))
+  - Rzk Playground now uses CodeMirror 6 and NextJS
+  - `miso` dependency is dropped
+  - GHCJS 9.6 is now used
+  - Support `snippet={code}` or `code={code}` param (see [#118](https://github.com/rzk-lang/rzk/pull/118))
+    - Support for `snippet_url={URL}` is temporarily dropped
+- Update to GHC 9.6, latest Stackage Nightly, improve Rzk setup, and GitHub Actions (see [#116](https://github.com/rzk-lang/rzk/pull/116))
+- Add logging for Rzk Language Server (see [#114](https://github.com/rzk-lang/rzk/pull/114))
+
+Fixes:
+
+- Fix error messages in Rzk Playground (see [#115](https://github.com/rzk-lang/rzk/pull/115))
+
 ## v0.6.4 — 2023-09-27
 
 This version improves the stucture of the project, in particular w.r.t dependencies:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.6.4
+version: 0.6.5
 github: 'rzk-lang/rzk'
 license: BSD3
 author: 'Nikolai Kudasov'

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.6.4
+version:        0.6.5
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types


### PR DESCRIPTION
This version contains mostly intrastructure improvements:

- Typecheck using `rzk.yaml` if it exists (see [#119](https://github.com/rzk-lang/rzk/pull/119))
- Update Rzk Playground and Nix Flake (see [#84](https://github.com/rzk-lang/rzk/pull/84))
  - Rzk Playground now uses CodeMirror 6 and NextJS
  - `miso` dependency is dropped
  - GHCJS 9.6 is now used
  - Support `snippet={code}` or `code={code}` param (see [#118](https://github.com/rzk-lang/rzk/pull/118))
    - Support for `snippet_url={URL}` is temporarily dropped
- Update to GHC 9.6, latest Stackage Nightly, improve Rzk setup, and GitHub Actions (see [#116](https://github.com/rzk-lang/rzk/pull/116))
- Add logging for Rzk Language Server (see [#114](https://github.com/rzk-lang/rzk/pull/114))

Fixes:

- Fix error messages in Rzk Playground (see [#115](https://github.com/rzk-lang/rzk/pull/115))