### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -33,7 +33,10 @@ permissions:
 jobs:
   build:
     name: "Build and test with GHC"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: rzk-bin.tar.gz
-          name: rzk-bin
+          name: rzk-${{ runner.os }}-${{ runner.arch }}.tar.gz
           if-no-files-found: error
 
   haddock:
@@ -99,7 +99,7 @@ jobs:
         id: download
         uses: actions/download-artifact@v3
         with:
-          name: rzk-bin
+          name: rzk-${{ runner.os }}-${{ runner.arch }}.tar.gz
 
       - name: Unpack rzk-bin.tar.gz
         run: |

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -50,6 +50,7 @@ jobs:
           mkdir -p bin/
           cp $(stack exec -- which rzk) bin/.
           tar -cvzf rzk-bin.tar.gz bin/
+        shell: bash
 
       - name: Upload rzk binary as Artifact
         uses: actions/upload-artifact@v3

--- a/rzk/Setup.hs
+++ b/rzk/Setup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- Source: https://github.com/haskell/cabal/issues/6726#issuecomment-918663262
 
 -- | Custom Setup that runs bnfc to generate the language sub-libraries
@@ -18,7 +19,9 @@ main :: IO ()
 main = defaultMainWithHooks $ simpleUserHooks
   { hookedPrograms = [ bnfcProgram ]
   , postConf       = \args flags packageDesc localBuildInfo -> do
+#ifndef mingw32_HOST_OS
       _ <- system "bnfc -d -p Language.Rzk --generic --functor -o src/ grammar/Syntax.cf"
+#endif
       postConf simpleUserHooks args flags packageDesc localBuildInfo
   }
 

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -60,6 +60,7 @@ ghc-options:
   - -Wmissing-home-modules
   - -Wpartial-fields
   - -Wredundant-constraints
+  - -optP-Wno-nonportable-include-path
 
 library:
   source-dirs: src

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -56,7 +56,7 @@ library
       Paths_rzk
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -99,7 +99,7 @@ executable rzk
       Paths_rzk
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -128,7 +128,7 @@ test-suite doctests
   main-is: doctests.hs
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -157,7 +157,7 @@ test-suite rzk-test
       Paths_rzk
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9


### PR DESCRIPTION
- Do not run BNFC on Windows (rely on pre-generated files). This is to avoid encoding issues (e.g. see https://github.com/rzk-lang/rzk/actions/runs/6372824473/job/17295991361#step:3:5176)
- Fix an issue with the build on macOS (using `-optP-Wno-nonportable-include-path` option advised in https://github.com/haskell/cabal/issues/4739#issuecomment-359209133).

Note that for Windows this is a temporary fix. Ideally, we would need BNFC to handle Unicode on Windows correctly or fix it somehow in the `Setup.hs`.