### PR TITLE
Release v0.6.6

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,5 +4,5 @@ authors:
   given-names: Nikolai
   orcid: "https://orcid.org/0000-0001-6572-7292"
 title: "Rzk: a  proof assistant for synthetic $\\infty$-categories"
-version: 0.6.5
+version: 0.6.6
 url: "https://github.com/rzk-lang/rzk"

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.6 — 2023-10-02
+
+- Fix builds on Windows (and macOS) (see [#121](https://github.com/rzk-lang/rzk/pull/121))
+
 ## v0.6.5 — 2023-10-01
 
 This version contains mostly intrastructure improvements:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,4 +14,4 @@ Using such representation is motivated by automatic handling of binders and easi
 
 An important part of `rzk` is a tope layer solver, which is essentially a theorem prover for a part of the type theory. A related project, dedicated just to that part is available at <https://github.com/fizruk/simple-topes>. `simple-topes` supports used-defined cubes, topes, and tope layer axioms. Once stable, `simple-topes` will be merged into `rzk`, expanding the proof assistant to the type theory with shapes, allowing formalisations for (variants of) cubical, globular, and other geometric versions of HoTT.
 
-See the list of contributors at [docs/docs/CONTRIBUTORS.md](docs/docs/CONTRIBUTORS.md).
+See the list of contributors at [CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,11 +7,11 @@ nav:
   - General:
     - About: index.md
     - Contributors: CONTRIBUTORS.md
+    - Changelog: CHANGELOG.md
   - Getting Started:
     - Install: getting-started/install.md
     - Quickstart: getting-started/quickstart.rzk.md
     - Publishing with MkDocs: getting-started/publishing-with-mkdocs.md
-    - Changelog: getting-started/changelog.md
   - Reference:
     - Introduction: reference/introduction.rzk.md
     - Cube layer: reference/cube-layer.rzk.md

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.6 — 2023-10-02
+
+- Fix builds on Windows (and macOS) (see [#121](https://github.com/rzk-lang/rzk/pull/121))
+
 ## v0.6.5 — 2023-10-01
 
 This version contains mostly intrastructure improvements:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.6.5
+version: 0.6.6
 github: 'rzk-lang/rzk'
 license: BSD3
 author: 'Nikolai Kudasov'

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.6.5
+version:        0.6.6
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types


### PR DESCRIPTION
- Fix builds on Windows (and macOS) (see [#121](https://github.com/rzk-lang/rzk/pull/121))