### PR TITLE
Release v0.6.7

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 authors:
-- family-names: Kudasov
-  given-names: Nikolai
-  orcid: "https://orcid.org/0000-0001-6572-7292"
+  - family-names: Kudasov
+    given-names: Nikolai
+    orcid: "https://orcid.org/0000-0001-6572-7292"
 title: "Rzk: a  proof assistant for synthetic $\\infty$-categories"
-version: 0.6.6
+version: 0.6.7
 url: "https://github.com/rzk-lang/rzk"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ However, for larger and multi-file formalisations you should install a version o
 - You can install the latest "stable" version of `rzk` from Hackage:
 
   ```sh
+  cabal update
   cabal install rzk
   ```
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.7 — 2023-10-07
+
+- Fix build on some systems (fix `BNFC:bnfc` executable dependency, see [#125](https://github.com/rzk-lang/rzk/pull/125))
+- Improve Rzk Playground (see [#124](https://github.com/rzk-lang/rzk/pull/124) by @deemp):
+  - Add `snippet_url` parameter
+  - Migrated from NextJS to Vite
+  - Use `setText` on `params` attribute
+- Slightly improve documentation:
+  - Add links to Rzk Zulip (see [#131](https://github.com/rzk-lang/rzk/pull/131))
+  - Add `cabal update` to instructions (see [`3aa8fd3`](https://github.com/rzk-lang/rzk/commit/3aa8fd38902fc8cbb29f86122410d24398a15b0b))
+
 ## v0.6.6 — 2023-10-02
 
 - Fix builds on Windows (and macOS) (see [#121](https://github.com/rzk-lang/rzk/pull/121))

--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -7,26 +7,26 @@ These instructions will walk you through setting up Rzk using the "basic" setup 
 1. Install [VS Code](https://code.visualstudio.com/).
 2. Launch VS Code and install the [`rzk` extension](https://marketplace.visualstudio.com/items?itemName=NikolaiKudasovfizruk.rzk-1-experimental-highlighting).
 3. Create a new file using "File > New Text File" (<kbd>Ctrl+N</kbd>). Click the `Select a language` prompt, type in `rzk`, and select "Literate Rzk Markdown".
-  ![VS Code rzk language selector.](../../assets/images/vscode-rzk-select-language.png)
+   ![VS Code rzk language selector.](../../assets/images/vscode-rzk-select-language.png)
 4. You should see the following popup:
-  ![VS Code rzk install prompt.](../../assets/images/vscode-rzk-install-prompt.png)
+   ![VS Code rzk install prompt.](../../assets/images/vscode-rzk-install-prompt.png)
 5. Click "Yes" button.
 6. While it is installing, you can paste the following literate Rzk program into the new file:
 
-    ````markdown
-    # Sample literate Rzk markdown
+   ````markdown
+   # Sample literate Rzk markdown
 
-    ```rzk
-    #lang rzk-1
-    
-    #define id (A : U)
-      : A -> A
-      := \ x -> x
-    ```
-    ````
+   ```rzk
+   #lang rzk-1
+
+   #define id (A : U)
+     : A -> A
+     := \ x -> x
+   ```
+   ````
 
 7. When the installation is done you should see the following popup:
-  ![VS Code rzk reload prompt.](../../assets/images/vscode-rzk-install-success-reload-prompt.png)
+   ![VS Code rzk reload prompt.](../../assets/images/vscode-rzk-install-success-reload-prompt.png)
 8. Click "Reload button".
 9. Save your file as `example.rzk.md`.
 10. Open local Terminal (<kbd>Ctrl+`</kbd>).
@@ -84,6 +84,7 @@ stack build && stack install
 To build and install with `cabal-install` from Hackage:
 
 ```sh
+cabal v2-update
 cabal v2-install rzk
 ```
 
@@ -99,4 +100,5 @@ cabal v2-build && cabal v2-install
 ### Nix
 
 !!! warning "Work-in-progress"
+
     To be done.

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.6.7 — 2023-10-07
+
+- Fix build on some systems (fix `BNFC:bnfc` executable dependency, see [#125](https://github.com/rzk-lang/rzk/pull/125))
+- Improve Rzk Playground (see [#124](https://github.com/rzk-lang/rzk/pull/124) by @deemp):
+  - Add `snippet_url` parameter
+  - Migrated from NextJS to Vite
+  - Use `setText` on `params` attribute
+- Slightly improve documentation:
+  - Add links to Rzk Zulip (see [#131](https://github.com/rzk-lang/rzk/pull/131))
+  - Add `cabal update` to instructions (see [`3aa8fd3`](https://github.com/rzk-lang/rzk/commit/3aa8fd38902fc8cbb29f86122410d24398a15b0b))
+
 ## v0.6.6 — 2023-10-02
 
 - Fix builds on Windows (and macOS) (see [#121](https://github.com/rzk-lang/rzk/pull/121))

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,10 +1,10 @@
 name: rzk
-version: 0.6.6
-github: 'rzk-lang/rzk'
+version: 0.6.7
+github: "rzk-lang/rzk"
 license: BSD3
-author: 'Nikolai Kudasov'
-maintainer: 'nickolay.kudasov@gmail.com'
-copyright: '2023 Nikolai Kudasov'
+author: "Nikolai Kudasov"
+maintainer: "nickolay.kudasov@gmail.com"
+copyright: "2023 Nikolai Kudasov"
 
 extra-source-files:
   - README.md
@@ -28,14 +28,14 @@ flags:
 
 custom-setup:
   dependencies:
-    base:    ">= 4.11.0.0 && < 5.0"
-    Cabal:   ">= 2.4.0.1 && < 4.0"
+    base: ">= 4.11.0.0 && < 5.0"
+    Cabal: ">= 2.4.0.1 && < 4.0"
     process: ">= 1.6.3.0"
 
 build-tools:
-  alex:   ">= 3.2.4"
-  happy:  ">= 1.19.9"
-  BNFC:bnfc:   ">= 2.9.4.1"
+  alex: ">= 3.2.4"
+  happy: ">= 1.19.9"
+  BNFC:bnfc: ">= 2.9.4.1"
 
 dependencies:
   array: ">= 0.5.3.0"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.6.6
+version:        0.6.7
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types


### PR DESCRIPTION
- Fix build on some systems (fix `BNFC:bnfc` executable dependency, see [#125](https://github.com/rzk-lang/rzk/pull/125))
- Improve Rzk Playground (see [#124](https://github.com/rzk-lang/rzk/pull/124) by @deemp):
  - Add `snippet_url` parameter
  - Migrated from NextJS to Vite
  - Use `setText` on `params` attribute
- Slightly improve documentation:
  - Add links to Rzk Zulip (see [#131](https://github.com/rzk-lang/rzk/pull/131))
  - Add `cabal update` to instructions (see [`3aa8fd3`](https://github.com/rzk-lang/rzk/commit/3aa8fd38902fc8cbb29f86122410d24398a15b0b))