### PR TITLE
Formatter - initial basic implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ Inside of such directory, you can run `rzk typecheck` on all files using wildcar
 rzk typecheck *-*.md
 ```
 
+### Formatting
+
+Formatting can be done by calling `rzk format` and specifying the files to be formatted, e.g.:
+
+```sh
+rzk format file1.rzk file2.rzk
+```
+
+This prints the formatted version of the file to `stdout`.
+
+To overwrite the file content, you must use the `--write` flag as such:
+
+```sh
+rzk format --write examples/*.rzk related/*.rzk.md
+```
+
+Note that if no files are specified, `rzk format` will format all files listed in `rzk.yaml`.
+
+The CLI also supports the `--check` flag, which will exit with a non-zero exit code if any of the files are not formatted correctly. This is useful in CI pipelines to ensure that all files are formatted correctly.
+
 ## How to contribute to `rzk`
 
 ### Building the Documentation Locally

--- a/flake.lock
+++ b/flake.lock
@@ -84,17 +84,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694934517,
-        "narHash": "sha256-U9aI4/jw+kYTZye4LJC2eIU30SqvZgL/UeRY4VHIjK8=",
+        "lastModified": 1701842937,
+        "narHash": "sha256-xIhu/49t/xQaHQu/XyOI1HkK7Lva1dMosD1TM4P+iWc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1b4c97ed4ce160afd9ef1574b6a2ff168482f2a",
+        "rev": "d1c3a8112f9d5d4840e0669727222e5fd9243451",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e1b4c97ed4ce160afd9ef1574b6a2ff168482f2a",
+        "rev": "d1c3a8112f9d5d4840e0669727222e5fd9243451",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
       packages = {
         default = default.packages.default;
         rzk = default.packages.${rzk};
+        rzk-ghcjs = ghcjs.packages.${rzk};
         rzk-js = ghcjs.packages.${rzk-js};
       } // scripts;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:NixOS/nixpkgs/e1b4c97ed4ce160afd9ef1574b6a2ff168482f2a";
+    nixpkgs.url = "github:NixOS/nixpkgs/d1c3a8112f9d5d4840e0669727222e5fd9243451";
     miso = {
       url = "github:dmjio/miso/49edf0677253bbcdd473422b5dd5b4beffd83910";
       flake = false;

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,2 +1,2 @@
 cradle:
-  cabal:
+  stack:

--- a/nix/ghcjs.nix
+++ b/nix/ghcjs.nix
@@ -1,34 +1,40 @@
 { inputs, pkgs, scripts, rzk, rzk-js, rzk-src, rzk-js-src, ghcVersion, tools }:
 let
   inherit (pkgs.haskell.lib) overrideCabal;
-  misoNix = (import "${inputs.miso.outPath}/default.nix" { inherit (pkgs) system; });
+  misoNix = (import "${inputs.miso}/default.nix" { inherit (pkgs) system; });
   pkgsMiso = misoNix.pkgs;
 
   hpkgs =
-    # This isn't equivalent to `pkgsMiso.haskell.packages.ghcjs.override` ([link](https://nixos.wiki/wiki/Haskell#Overrides))
-    # but avoids multiple rebuilds
-    pkgsMiso.haskell.packages.ghcjs //
-    {
-      rzk = overrideCabal
-        (hpkgs.callCabal2nix rzk rzk-src { })
-        (x: {
-          isLibrary = true;
-          isExecutable = false;
+    pkgsMiso.haskell.packages.ghcjs.override {
+      overrides = final: prev: {
+        mkDerivation = args: prev.mkDerivation (args // {
           doCheck = false;
           doHaddock = false;
-          libraryToolDepends = [ pkgs.hpack pkgs.alex pkgs.happy ] ++ (x.libraryToolDepends or [ ]);
-          testToolDepends = [ pkgs.hpack pkgs.alex pkgs.happy ] ++ (x.testToolDepends or [ ]);
-          prePatch = "hpack --force";
         });
-      rzk-js = overrideCabal
-        (hpkgs.callCabal2nix rzk-js rzk-js-src { inherit (hpkgs) rzk; })
-        (x: {
-          postInstall = (x.postInstall or "") + ''
-            cp $out/bin/${rzk-js} .
-            rm -r $out
-            cp ${rzk-js} $out
-          '';
+        hpack = pkgs.hpack;
+        rzk = (
+          (pkgsMiso.haskell.lib.overrideCabal
+            (prev.callCabal2nix rzk rzk-src { })
+            (x: {
+              isLibrary = true;
+              isExecutable = false;
+              buildTarget = "lib:rzk";
+              libraryToolDepends = [ pkgs.hpack pkgs.alex pkgs.happy ] ++ (x.libraryToolDepends or [ ]);
+              testToolDepends = [ pkgs.alex pkgs.happy ] ++ (x.testToolDepends or [ ]);
+            }))
+        ).overrideAttrs (x: {
+          installPhase = builtins.replaceStrings [ "Setup copy" ] [ "Setup copy lib:rzk" ] x.installPhase;
         });
+        rzk-js = overrideCabal
+          (final.callCabal2nix rzk-js rzk-js-src { })
+          (x: {
+            postInstall = (x.postInstall or "") + ''
+              cp $out/bin/${rzk-js} .
+              rm -r $out
+              cp ${rzk-js} $out
+            '';
+          });
+      };
     };
 
   hpkgsGHCJS_8_10_7 = pkgs.haskell.packages.ghcjs810.override ({

--- a/rzk/app/Main.hs
+++ b/rzk/app/Main.hs
@@ -1,14 +1,92 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
+
 module Main (main) where
 
 #ifndef __GHCJS__
 import           Main.Utf8 (withUtf8)
 #endif
-import qualified Rzk.Main
+
+import           Control.Monad           (forM, forM_, unless, when,
+                                          (>=>))
+import           Data.Version            (showVersion)
+
+#ifdef LSP
+import           Language.Rzk.VSCode.Lsp (runLsp)
+#endif
+
+import           Options.Generic
+import           System.Exit             (exitFailure, exitSuccess)
+
+import           Data.Functor            ((<&>))
+import           Paths_rzk               (version)
+import           Rzk.Format              (formatFile, formatFileWrite,
+                                          isWellFormattedFile)
+import           Rzk.TypeCheck
+import           Rzk.Main
+
+data FormatOptions = FormatOptions
+  { check :: Bool
+  , write :: Bool
+  } deriving (Generic, Show, ParseRecord, Read, ParseField)
+
+instance ParseFields FormatOptions where
+  parseFields _ _ _ _ = FormatOptions
+    <$> parseFields (Just "Check if the files are correctly formatted") (Just "check") (Just 'c') Nothing
+    <*> parseFields (Just "Write formatted file to disk") (Just "write") (Just 'w') Nothing
+
+data Command
+  = Typecheck [FilePath]
+  | Lsp
+  | Format FormatOptions [FilePath]
+  | Version
+  deriving (Generic, Show, ParseRecord)
 
 main :: IO ()
-main =
+main = do
 #ifndef __GHCJS__
-  withUtf8
+  withUtf8 $
 #endif
-    Rzk.Main.main
+    getRecord "rzk: an experimental proof assistant for synthetic ∞-categories" >>= \case
+    Typecheck paths -> do
+      modules <- parseRzkFilesOrStdin paths
+      case defaultTypeCheck (typecheckModulesWithLocation modules) of
+        Left err -> do
+          putStrLn "An error occurred when typechecking!"
+          putStrLn $ unlines
+            [ "Type Error:"
+            , ppTypeErrorInScopedContext' BottomUp err
+            ]
+          exitFailure
+        Right _decls -> putStrLn "Everything is ok!"
+
+    Lsp ->
+#ifdef LSP
+      void runLsp
+#else
+      error "rzk lsp is not supported with this build"
+#endif
+
+    Format (FormatOptions check write) paths -> do
+      when (check && write) (error "Options --check and --write are mutually exclusive")
+      expandedPaths <- expandRzkPathsOrYaml paths
+      case expandedPaths of
+        [] -> error "No files found"
+        filePaths -> do
+          when (not check && not write) $ forM_ filePaths (formatFile >=> putStrLn)
+          when write $ forM_ filePaths formatFileWrite
+          when check $ do
+            results <- forM filePaths $ \path -> isWellFormattedFile path <&> (path,)
+            let notFormatted = map fst $ filter (not . snd) results
+            unless (null notFormatted) $ do
+              putStrLn "Some files are not well formatted:"
+              forM_ notFormatted $ \path -> putStrLn ("  " <> path)
+              exitFailure
+            exitSuccess
+
+    Version -> putStrLn (showVersion version)
+

--- a/rzk/app/Main.hs
+++ b/rzk/app/Main.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Main (main) where
 
@@ -71,7 +72,7 @@ main = do
       error "rzk lsp is not supported with this build"
 #endif
 
-    Format (FormatOptions check write) paths -> do
+    Format (FormatOptions {check, write}) paths -> do
       when (check && write) (error "Options --check and --write are mutually exclusive")
       expandedPaths <- expandRzkPathsOrYaml paths
       case expandedPaths of

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -45,7 +45,6 @@ dependencies:
   directory: ">= 1.2.7.0"
   Glob: ">= 0.9.3"
   mtl: ">= 2.2.2"
-  optparse-generic: ">= 1.4.0"
   template-haskell: ">= 2.14.0.0"
   text: ">= 1.2.3.1"
   yaml: ">= 0.11.0.0"
@@ -103,6 +102,7 @@ executables:
       - condition: "!impl(ghcjs)"
         dependencies:
           with-utf8: ">= 1.0.2.4"
+          optparse-generic: ">= 1.4.0"
 
 tests:
   rzk-test:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -45,7 +45,7 @@ dependencies:
   directory: ">= 1.2.7.0"
   Glob: ">= 0.9.3"
   mtl: ">= 2.2.2"
-  optparse-generic: ">= 1.3.0"
+  optparse-generic: ">= 1.4.0"
   template-haskell: ">= 2.14.0.0"
   text: ">= 1.2.3.1"
   yaml: ">= 0.11.0.0"

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -72,11 +72,12 @@ library:
         - Language.Rzk.Syntax.Skel
     - condition: flag(lsp) && !impl(ghcjs)
       exposed-modules:
+        - Language.Rzk.VSCode.Config
         - Language.Rzk.VSCode.Env
         - Language.Rzk.VSCode.Handlers
+        - Language.Rzk.VSCode.Logging
         - Language.Rzk.VSCode.Lsp
         - Language.Rzk.VSCode.Tokenize
-        - Language.Rzk.VSCode.Logging
       dependencies:
         aeson: ">= 1.4.2.0"
         co-log-core: ">= 0.3.2.0"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -49,6 +49,7 @@ library
       Language.Rzk.Syntax.Par
       Language.Rzk.Syntax.Print
       Rzk
+      Rzk.Format
       Rzk.Main
       Rzk.Project.Config
       Rzk.TypeCheck

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -48,6 +48,7 @@ library
       Language.Rzk.Syntax.Lex
       Language.Rzk.Syntax.Par
       Language.Rzk.Syntax.Print
+      Language.Rzk.VSCode.Config
       Rzk
       Rzk.Format
       Rzk.Main

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -71,7 +71,6 @@ library
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
     , mtl >=2.2.2
-    , optparse-generic >=1.4.0
     , template-haskell >=2.14.0.0
     , text >=1.2.3.1
     , yaml >=0.11.0.0
@@ -115,7 +114,6 @@ executable rzk
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
     , mtl >=2.2.2
-    , optparse-generic >=1.4.0
     , rzk
     , template-haskell >=2.14.0.0
     , text >=1.2.3.1
@@ -123,7 +121,8 @@ executable rzk
   default-language: Haskell2010
   if !impl(ghcjs)
     build-depends:
-        with-utf8 >=1.0.2.4
+        optparse-generic >=1.4.0
+      , with-utf8 >=1.0.2.4
 
 test-suite doctests
   type: exitcode-stdio-1.0
@@ -146,7 +145,6 @@ test-suite doctests
     , directory >=1.2.7.0
     , doctest
     , mtl >=2.2.2
-    , optparse-generic >=1.4.0
     , template-haskell
     , text >=1.2.3.1
     , yaml >=0.11.0.0
@@ -173,7 +171,6 @@ test-suite rzk-test
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
     , mtl >=2.2.2
-    , optparse-generic >=1.4.0
     , rzk
     , template-haskell >=2.14.0.0
     , text >=1.2.3.1

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -48,7 +48,6 @@ library
       Language.Rzk.Syntax.Lex
       Language.Rzk.Syntax.Par
       Language.Rzk.Syntax.Print
-      Language.Rzk.VSCode.Config
       Rzk
       Rzk.Format
       Rzk.Main
@@ -72,18 +71,19 @@ library
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
     , mtl >=2.2.2
-    , optparse-generic >=1.3.0
+    , optparse-generic >=1.4.0
     , template-haskell >=2.14.0.0
     , text >=1.2.3.1
     , yaml >=0.11.0.0
   default-language: Haskell2010
   if flag(lsp) && !impl(ghcjs)
     exposed-modules:
+        Language.Rzk.VSCode.Config
         Language.Rzk.VSCode.Env
         Language.Rzk.VSCode.Handlers
+        Language.Rzk.VSCode.Logging
         Language.Rzk.VSCode.Lsp
         Language.Rzk.VSCode.Tokenize
-        Language.Rzk.VSCode.Logging
     cpp-options: -DLSP
     build-depends:
         aeson >=1.4.2.0
@@ -115,7 +115,7 @@ executable rzk
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
     , mtl >=2.2.2
-    , optparse-generic >=1.3.0
+    , optparse-generic >=1.4.0
     , rzk
     , template-haskell >=2.14.0.0
     , text >=1.2.3.1
@@ -146,7 +146,7 @@ test-suite doctests
     , directory >=1.2.7.0
     , doctest
     , mtl >=2.2.2
-    , optparse-generic >=1.3.0
+    , optparse-generic >=1.4.0
     , template-haskell
     , text >=1.2.3.1
     , yaml >=0.11.0.0
@@ -173,7 +173,7 @@ test-suite rzk-test
     , bytestring >=0.10.8.2
     , directory >=1.2.7.0
     , mtl >=2.2.2
-    , optparse-generic >=1.3.0
+    , optparse-generic >=1.4.0
     , rzk
     , template-haskell >=2.14.0.0
     , text >=1.2.3.1

--- a/rzk/src/Language/Rzk/VSCode/Config.hs
+++ b/rzk/src/Language/Rzk/VSCode/Config.hs
@@ -10,13 +10,11 @@ import           Data.Default.Class (Default, def)
 
 data ServerConfig = ServerConfig
   { formatEnabled          :: Bool
-  , formatMessageDisplayed :: Bool
   } deriving Show
 
 instance Default ServerConfig where
   def = ServerConfig
     { formatEnabled = True
-    , formatMessageDisplayed = False
     }
 
 -- We need to derive the FromJSON instance manually in order to provide defaults
@@ -26,15 +24,11 @@ instance FromJSON ServerConfig where
   parseJSON = withObject "rzkSettings" $ \rzkSettings -> do
     formatSettings <- rzkSettings .: "format" -- TODO: how to make this optional?
     formatEnabled <- formatSettings .:? "enable" .!= formatEnabled def
-    formatMessageDisplayed <- rzkSettings .:? "format.messageDisplayed" .!= formatMessageDisplayed def
     return ServerConfig { .. }
 
 instance ToJSON ServerConfig where
   toJSON (ServerConfig { .. }) = object
-    -- [ "rzk" .= object
-        [ "format" .= object
-            [ "enable" .= formatEnabled
-            , "messageDisplayed" .= formatMessageDisplayed
-            ]
-        ]
-    -- ]
+      [ "format" .= object
+          [ "enable" .= formatEnabled
+          ]
+      ]

--- a/rzk/src/Language/Rzk/VSCode/Config.hs
+++ b/rzk/src/Language/Rzk/VSCode/Config.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Language.Rzk.VSCode.Config (
+  ServerConfig(..),
+) where
+
+import           Data.Aeson
+import           Data.Default.Class (Default, def)
+
+data ServerConfig = ServerConfig
+  { formatEnabled          :: Bool
+  , formatMessageDisplayed :: Bool
+  } deriving Show
+
+instance Default ServerConfig where
+  def = ServerConfig
+    { formatEnabled = True
+    , formatMessageDisplayed = False
+    }
+
+-- We need to derive the FromJSON instance manually in order to provide defaults
+-- for absent fields.
+instance FromJSON ServerConfig where
+  -- Note: "configSection" in ServerDefinition already filters by the "rzk." prefix
+  parseJSON = withObject "rzkSettings" $ \rzkSettings -> do
+    formatSettings <- rzkSettings .: "format" -- TODO: how to make this optional?
+    formatEnabled <- formatSettings .:? "enable" .!= formatEnabled def
+    formatMessageDisplayed <- rzkSettings .:? "format.messageDisplayed" .!= formatMessageDisplayed def
+    return ServerConfig { .. }
+
+instance ToJSON ServerConfig where
+  toJSON (ServerConfig { .. }) = object
+    -- [ "rzk" .= object
+        [ "format" .= object
+            [ "enable" .= formatEnabled
+            , "messageDisplayed" .= formatMessageDisplayed
+            ]
+        ]
+    -- ]

--- a/rzk/src/Language/Rzk/VSCode/Env.hs
+++ b/rzk/src/Language/Rzk/VSCode/Env.hs
@@ -3,7 +3,8 @@ module Language.Rzk.VSCode.Env where
 import           Control.Concurrent.STM
 import           Control.Monad.Reader
 import           Language.LSP.Server
-import           Rzk.TypeCheck          (Decl')
+import           Language.Rzk.VSCode.Config (ServerConfig)
+import           Rzk.TypeCheck              (Decl')
 
 type RzkTypecheckCache = [(FilePath, [Decl'])]
 
@@ -18,7 +19,7 @@ defaultRzkEnv = do
     { rzkEnvTypecheckCache = typecheckCache }
 
 
-type LSP = LspT () (ReaderT RzkEnv IO)
+type LSP = LspT ServerConfig (ReaderT RzkEnv IO)
 
 -- | Override the cache with given typechecked modules.
 cacheTypecheckedModules :: RzkTypecheckCache -> LSP ()

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -33,10 +33,13 @@ import           Language.LSP.VFS              (virtualFileText)
 import           System.FilePath               (makeRelative, (</>))
 import           System.FilePath.Glob          (compile, globDir)
 
+import           Control.Monad.Trans           (lift)
+import           Data.Aeson                    (ToJSON (toJSON))
 import           Language.Rzk.Free.Syntax      (RzkPosition (RzkPosition),
                                                 VarIdent (getVarIdent))
 import           Language.Rzk.Syntax           (Module, VarIdent' (VarIdent),
                                                 parseModuleFile, printTree)
+import           Language.Rzk.VSCode.Config    (ServerConfig (ServerConfig, formatEnabled, formatMessageDisplayed))
 import           Language.Rzk.VSCode.Env
 import           Language.Rzk.VSCode.Logging
 import           Rzk.Format                    (FormattingEdit (..),
@@ -225,12 +228,40 @@ formattingEditToTextEdit (FormattingEdit startLine startCol endLine endCol newTe
 
 formatDocument :: Handler LSP 'Method_TextDocumentFormatting
 formatDocument req res = do
-  logDebug "Formatting document"
   let doc = req ^. params . textDocument . uri . to toNormalizedUri
+  logInfo $ "Formatting document: " <> show doc
+  config@(ServerConfig {formatEnabled = fmtEnabled, formatMessageDisplayed = fmtMsgDisplayed}) <- getConfig
+  logInfo $ "Format enabled: " <> show fmtEnabled
+  logInfo $ "Format prompt displayed: " <> show fmtMsgDisplayed
+  -- unless formatEnabled $ do
+  --   res $ Left $ ResponseError (InR ErrorCodes_InternalError) "Formatting is disabled" Nothing
+  --   return ()
+
   mdoc <- getVirtualFile doc
   possibleEdits <- case virtualFileText <$> mdoc of
     Nothing         -> return (Left "Failed to get file contents")
     Just sourceCode -> return (Right $ map formattingEditToTextEdit $ formatTextEdits (filter (/= '\r') $ T.unpack sourceCode))
   case possibleEdits of
     Left err    -> res $ Left $ ResponseError (InR ErrorCodes_InternalError) err Nothing
-    Right edits -> res $ Right $ InL edits
+    Right edits -> do
+      res $ Right $ InL edits
+
+      _ <- sendRequest SMethod_WindowShowMessageRequest
+        (ShowMessageRequestParams
+          MessageType_Info
+          "Formatting is enabled!"
+          (Just
+            [ MessageActionItem "Yay!"
+            , MessageActionItem "I don't like it :("
+            ])
+        )
+        handleResponse
+      _ <- tryChangeConfig mempty (toJSON $ config { formatMessageDisplayed = True })
+      return ()
+  where
+    handleResponse :: Either ResponseError (MessageResult 'Method_WindowShowMessageRequest) -> LSP ()
+    handleResponse (Left err) = logError ("Failed to show message: " ++ show err)
+    handleResponse (Right (InR Null)) = logInfo "Received no response. Keeping the formatter enabled"
+    handleResponse (Right (InL (MessageActionItem msg))) = do
+      logInfo ("Received response: " ++ T.unpack msg)
+      return () -- TODO: handle

--- a/rzk/src/Language/Rzk/VSCode/Handlers.hs
+++ b/rzk/src/Language/Rzk/VSCode/Handlers.hs
@@ -229,7 +229,7 @@ formatDocument req res = do
   let doc = req ^. params . textDocument . uri . to toNormalizedUri
   logInfo $ "Formatting document: " <> show doc
   ServerConfig {formatEnabled = fmtEnabled} <- getConfig
-  when fmtEnabled $ do
+  if fmtEnabled then do
     mdoc <- getVirtualFile doc
     possibleEdits <- case virtualFileText <$> mdoc of
       Nothing         -> return (Left "Failed to get file contents")
@@ -238,3 +238,6 @@ formatDocument req res = do
       Left err    -> res $ Left $ ResponseError (InR ErrorCodes_InternalError) err Nothing
       Right edits -> do
         res $ Right $ InL edits
+  else do
+    logDebug "Formatting is disabled in config"
+    res $ Right $ InR Null

--- a/rzk/src/Language/Rzk/VSCode/Lsp.hs
+++ b/rzk/src/Language/Rzk/VSCode/Lsp.hs
@@ -52,6 +52,8 @@ handlers =
         -- TODO: check if the file is included in the config's `include` list.
         --       If not (and not in `exclude`) either, issue a warning.
         return () -- FIXME: typecheck standalone files (if they are not a part of the project)
+    -- An empty hadler is needed to silence the error since it is already handled by the LSP package
+    , notificationHandler SMethod_WorkspaceDidChangeConfiguration $ const $ pure ()
     -- , requestHandler SMethod_TextDocumentHover $ \req responder -> do
     --    TODO: Read from the list of symbols that is supposed to be cached by the typechecker
     --     let TRequestMessage _ _ _ (HoverParams _doc pos _workDone) = req

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -177,6 +177,9 @@ formatTextEdits contents = go initialState toks
           [ (spacesAfter /= 1, FormattingEdit line spaceCol line (spaceCol + spacesAfter) " ")
           ]
 
+    -- Reset any state necessary after finishing a command
+    go s (Token ";" _ _ : tks) = go s tks
+
     -- One space (or new line) around binary operators and replace ASCII w/ unicode
     go s (Token tk line col : tks) = edits ++ go s' tks
       where
@@ -234,8 +237,6 @@ formatTextEdits contents = go initialState toks
           , ("*", "×")
           ]
 
-    -- Reset any state necessary after finishing a command
-    go s (Token ";" _ _ : tks) = go s tks
     go s (_:tks) = go s tks
 
 -- Adapted from https://hackage.haskell.org/package/lsp-types-2.1.0.0/docs/Language-LSP-Protocol-Types.html#g:7

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -210,7 +210,7 @@ formatTextEdits contents = go initialState toks
               -- If last char in line, move it to next line (except for lambda arrow)
               , (isLastNonSpaceChar && not (lambdaArrow s),
                   FormattingEdit line (col - spacesBefore) (line + 1) (spacesNextLine + 1) $
-                    "\n" ++ replicate spacesNextLine ' ' ++ tk ++ " ")
+                    "\n" ++ replicate (2 `max` (spacesNextLine - (spacesNextLine `min` 2))) ' ' ++ tk ++ " ")
               -- If lambda -> is first char in line, move it to the previous line
               , (isFirstNonSpaceChar && isArrow && lambdaArrow s,
                   FormattingEdit (line - 1) (length prevLine + 1) line (col + length tk + spacesAfter) $

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -120,11 +120,14 @@ formatTextEdits contents = go initialState toks
       where
         spaceCol = col + 1
         lineContent = contentLines line
-        precededBySingleCharOnly = all isPunctuation (words (take (col - 1) lineContent))
-        isPunctuation tk = tk `elem` concat
+        -- | This is similar to (\\) but removes all occurrences (not just the first one)
+        setDifference xs excludes = filter (not . (`elem` excludes)) xs
+        precededBySingleCharOnly = null $ foldl' setDifference (take (col - 1) lineContent) punctuations
+        punctuations = concat
           [ map fst unicodeTokens -- ASCII sequences will be converted soon
           , map snd unicodeTokens
           , ["(", ":", ",", "="]
+          , [" ", "\t"]
           ]
         spacesAfter = length $ takeWhile (== ' ') (drop col lineContent)
         isLastNonSpaceChar = all (== ' ') (drop col lineContent)

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -75,6 +75,8 @@ formatTextEdits contents = go initialState toks
               FormattingEdit langLine (langCol + 5) rzkLine rzkCol " ")
           ]
 
+    go s (Token "#postulate" _ _ : tks) = go (s {definingName = True}) tks
+
     go s (Token "#define" defLine defCol : TokenIdent _name nameLine nameCol : tks)
       = edits ++ go (s {definingName = True}) tks
       where

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -1,0 +1,129 @@
+{-|
+Module      : Formatter
+Description : This module defines the formatter for rzk files.
+
+The formatter is designed in a way that can be consumed both by the CLI and the
+LSP server.
+-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms   #-}
+module Rzk.Format where
+
+import qualified Data.Text                   as T
+
+import           Language.LSP.Protocol.Types (Position (Position),
+                                              Range (Range),
+                                              TextEdit (TextEdit))
+import           Language.Rzk.Syntax         (tryExtractMarkdownCodeBlocks)
+import           Language.Rzk.Syntax.Layout  (resolveLayout)
+import           Language.Rzk.Syntax.Lex     (Posn (Pn), Tok (TK),
+                                              TokSymbol (TokSymbol), Token (PT),
+                                              tokens)
+
+mkEdit :: Int -> Int -> Int -> Int -> String -> TextEdit
+mkEdit startLine startCol endLine endCol newText =
+  TextEdit (Range (Position (fromIntegral startLine - 1) (fromIntegral startCol - 1)) (Position (fromIntegral endLine - 1) (fromIntegral endCol - 1))) (T.pack newText)
+
+-- TODO: more patterns, e.g. for identifiers and literals
+pattern Symbol :: String -> Tok
+pattern Symbol s <- TK (TokSymbol s _)
+
+pattern Token :: String -> Int -> Int -> Token
+pattern Token s line col <- PT (Pn _ line col) (Symbol s)
+
+data FormatState = FormatState {
+  parenDepth  :: Int,
+  indentation :: Int
+}
+
+formatTextEdits :: String -> [TextEdit]
+formatTextEdits contents = go toks
+  where
+    rzkBlocks = tryExtractMarkdownCodeBlocks "rzk" contents -- TODO: replace tabs with spaces
+    contentLines line = lines rzkBlocks !! (line - 1) -- Sorry
+    toks = resolveLayout True (tokens rzkBlocks)
+    go :: [Token] -> [TextEdit]
+    go [] = []
+    -- Remove extra spaces between #lang and rzk-1
+    go (Token "#lang" langLine langCol : Token "rzk-1" rzkLine rzkCol : tks)
+      -- FIXME: Tab characters break this because BNFC increases the column number to the next multiple of 8
+      -- Should probably check the first field of Pn (always incremented by 1)
+      -- Or `tabSize` param sent along the formatting request
+      -- But we should probably convert tabs to spaces first before any other formatting
+      | rzkLine > langLine || rzkCol > langCol + 5 + 1
+        = mkEdit langLine (langCol + 5) rzkLine rzkCol " "
+        : go tks
+
+    -- TODO: only one space (or line break) after #define
+    -- TODO: only one space (or line break) after #define name
+
+    -- Ensure exactly one space after the first open paren of a line
+    go (Token "(" line col : tks)
+      | isFirstNonSpaceChar && spacesAfter /= 1
+        = mkEdit line spaceCol line (spaceCol + spacesAfter) " "
+        : go tks
+      where
+        spaceCol = col + 1
+        lineContent = contentLines line
+        isFirstNonSpaceChar = all (== ' ') (take (col - 1) lineContent)
+        spacesAfter = length $ takeWhile (== ' ') (drop col lineContent)
+
+    -- TODO: line break before : (only the top-level one) and one space after
+
+    -- Line break before := and one space after
+    go (Token ":=" line col : tks)
+      -- TODO: combine these 2 rules. they are not mutually exclusive
+      -- Also, ensure 2 spaces before
+      | not isFirstNonSpaceChar
+        -- TODO: trim possible spaces before as well
+        = mkEdit line col line col "\n  "
+        : go tks
+      | length lineContent > col + 2 && spacesAfter /= 1
+        = mkEdit line (col + 2) line (col + 2 + spacesAfter) " "
+        : go tks
+      where
+        lineContent = contentLines line
+        isFirstNonSpaceChar = all (== ' ') (take (col - 1) lineContent)
+        spacesAfter = length $ takeWhile (== ' ') (drop (col + 1) lineContent)
+        edits = [
+            (not isFirstNonSpaceChar, mkEdit line col line col "\n  ")
+          ]
+    -- TOOD: move any binary operators at the end of a line to the beginning of the next
+    -- TODO: any binary operator should have one space after
+
+    -- Replace some ASCII sequences with their Unicode equivalent
+    go (Token "->" line col : tks)  = mkEdit line col line (col + 2) "→" : go tks
+    go (Token "|->" line col : tks) = mkEdit line col line (col + 3) "↦" : go tks
+    go (Token "===" line col : tks) = mkEdit line col line (col + 3) "≡" : go tks
+    go (Token "<=" line col : tks)  = mkEdit line col line (col + 2) "≤" : go tks
+    go (Token "/\\" line col : tks)  = mkEdit line col line (col + 2) "∧" : go tks
+    go (Token "\\/" line col : tks)  = mkEdit line col line (col + 2) "∨" : go tks
+    go (Token "Sigma" line col : tks)  = mkEdit line col line (col + 5) "Σ" : go tks
+    go (Token "∑" line col : tks)  = mkEdit line col line (col + 1) "Σ" : go tks
+
+    -- TODO: 0_2, 1_2, I * J
+    go (_:tks) = go tks
+
+applyTextEdits :: [TextEdit] -> String -> String
+applyTextEdits edits contents = contents
+
+
+format :: String -> String
+format = applyTextEdits =<< formatTextEdits
+
+
+-- | Format Rzk code from a file, returning the formatted version.
+formatFile :: FilePath -> IO String
+formatFile path = do
+  contents <- readFile path
+  return (format contents)
+
+-- | Check if the given Rzk source code is well formatted.
+--   This is useful for automation tasks.
+isWellFormatted :: String -> Bool
+isWellFormatted src = src == format src
+
+formatFileWrite :: FilePath -> IO ()
+formatFileWrite path = do
+  formatted <- formatFile path
+  writeFile path formatted

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -132,8 +132,8 @@ formatTextEdits contents = go initialState toks
         spaceCol = col + 1
         spacesAfter = length $ takeWhile (== ' ') (drop col lineContent)
         typeSepEdits = map snd $ filter fst
-          -- Ensure line break before :
-          [ (not isFirstNonSpaceChar, FormattingEdit line col line col "\n  ")
+          -- Ensure line break before : (and remove any spaces before)
+          [ (not isFirstNonSpaceChar, FormattingEdit line (col - spacesBefore) line col "\n  ")
           -- Ensure 2 spaces before : (if already on a new line)
           , (isFirstNonSpaceChar && spacesBefore /= 2, FormattingEdit line 1 line col "  ")
           -- Ensure 1 space after
@@ -153,10 +153,10 @@ formatTextEdits contents = go initialState toks
         lineContent = contentLines line
         isFirstNonSpaceChar = all (== ' ') (take (col - 1) lineContent)
         spacesAfter = length $ takeWhile (== ' ') (drop (col + 1) lineContent)
-        spacesBefore = length $ takeWhile (== ' ') (take (col - 1) lineContent)
+        spacesBefore = length $ takeWhile (== ' ') (reverse $ take (col - 1) lineContent)
         edits = map snd $ filter fst
             -- Ensure line break before `:=`
-          [ (not isFirstNonSpaceChar, FormattingEdit line col line col "\n  ")
+          [ (not isFirstNonSpaceChar, FormattingEdit line (col - spacesBefore) line col "\n  ")
             -- Ensure 2 spaces before `:=` (if already on a new line)
           , (isFirstNonSpaceChar && spacesBefore /= 2,
               FormattingEdit line 1 line col "  ")
@@ -199,7 +199,7 @@ formatTextEdits contents = go initialState toks
               FormattingEdit line (col + length binOp) line (col + length binOp + spacesAfter) " ")
           -- If last char in line, move it to next line
           , (isLastNonSpaceChar,
-              FormattingEdit line col (line + 1) (spacesNextLine + 1) $
+              FormattingEdit line (col - spacesBefore) (line + 1) (spacesNextLine + 1) $
                 "\n" ++ replicate spacesNextLine ' ' ++ binOp ++ " ")
           ]
 

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -176,9 +176,9 @@ formatTextEdits contents = go initialState toks
           [ (spacesAfter /= 1, FormattingEdit line spaceCol line (spaceCol + spacesAfter) " ")
           ]
 
-    -- One space (or new line) around binary operators ('->' or '→' or ',')
+    -- One space (or new line) around binary operators ('→' or ',')
     go s (Token binOp line col : tks)
-      | binOp `elem` ["->", "→", ","]
+      | binOp `elem` ["→", ","]
       = edits ++ go s tks
       where
         lineContent = contentLines line

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -200,7 +200,7 @@ formatTextEdits contents = go initialState toks
         spacesNextLine = length $ takeWhile (== ' ') nextLine
         edits = spaceEdits ++ unicodeEdits
         spaceEdits
-          | tk `elem` ["->", "→", ",", "*", "×"] = map snd $ filter fst
+          | tk `elem` ["->", "→", ",", "*", "×", "="] = map snd $ filter fst
               -- Ensure exactly one space before (unless first char in line)
               [ (not isFirstNonSpaceChar && spacesBefore /= 1,
                   FormattingEdit line (col - spacesBefore) line col " ")

--- a/rzk/src/Rzk/Format.hs
+++ b/rzk/src/Rzk/Format.hs
@@ -226,8 +226,8 @@ formatTextEdits contents = go initialState toks
         edits = spaceEdits ++ unicodeEdits
         spaceEdits
           | tk `elem` ["->", "→", ",", "*", "×", "="] = map snd $ filter fst
-              -- Ensure exactly one space before (unless first char in line)
-              [ (not isFirstNonSpaceChar && spacesBefore /= 1,
+              -- Ensure exactly one space before (unless first char in line, or about to move to next line)
+              [ (not isFirstNonSpaceChar && spacesBefore /= 1 && not isLastNonSpaceChar,
                   FormattingEdit line (col - spacesBefore) line col " ")
               -- Ensure exactly one space after (unless last char in line)
               , (not isLastNonSpaceChar && spacesAfter /= 1,

--- a/rzk/src/Rzk/Main.hs
+++ b/rzk/src/Rzk/Main.hs
@@ -1,93 +1,20 @@
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeApplications  #-}
 
 module Rzk.Main where
 
-import           Control.Monad           (forM, forM_, unless, void, when,
-                                          (>=>))
+import           Control.Monad           (forM, when)
 import           Data.List               (sort)
-import           Data.Version            (showVersion)
-
-#ifdef LSP
-import           Language.Rzk.VSCode.Lsp (runLsp)
-#endif
-
 import qualified Data.Yaml               as Yaml
-import           Options.Generic
 import           System.Directory        (doesPathExist)
-import           System.Exit             (exitFailure, exitSuccess)
 import           System.FilePath.Glob    (glob)
-
-import           Data.Functor            ((<&>))
 import qualified Language.Rzk.Syntax     as Rzk
-import           Paths_rzk               (version)
-import           Rzk.Format              (formatFile, formatFileWrite,
-                                          isWellFormattedFile)
 import           Rzk.Project.Config
 import           Rzk.TypeCheck
 
-data FormatOptions = FormatOptions
-  { check :: Bool
-  , write :: Bool
-  } deriving (Generic, Show, ParseRecord, Read, ParseField)
 
-instance ParseFields FormatOptions where
-  parseFields _ _ _ _ = FormatOptions
-    <$> parseFields (Just "Check if the files are correctly formatted") (Just "check") (Just 'c') Nothing
-    <*> parseFields (Just "Write formatted file to disk") (Just "write") (Just 'w') Nothing
-
-data Command
-  = Typecheck [FilePath]
-  | Lsp
-  | Format FormatOptions [FilePath]
-  | Version
-  deriving (Generic, Show, ParseRecord)
-
-main :: IO ()
-main = getRecord "rzk: an experimental proof assistant for synthetic ∞-categories" >>= \case
-  Typecheck paths -> do
-    modules <- parseRzkFilesOrStdin paths
-    case defaultTypeCheck (typecheckModulesWithLocation modules) of
-      Left err -> do
-        putStrLn "An error occurred when typechecking!"
-        putStrLn $ unlines
-          [ "Type Error:"
-          , ppTypeErrorInScopedContext' BottomUp err
-          ]
-        exitFailure
-      Right _decls -> putStrLn "Everything is ok!"
-
-  Lsp ->
-#ifdef LSP
-    void runLsp
-#else
-    error "rzk lsp is not supported with this build"
-#endif
-
-  Format (FormatOptions check write) paths -> do
-    when (check && write) (error "Options --check and --write are mutually exclusive")
-    expandedPaths <- expandRzkPathsOrYaml paths
-    case expandedPaths of
-      [] -> error "No files found"
-      filePaths -> do
-        when (not check && not write) $ forM_ filePaths (formatFile >=> putStrLn)
-        when write $ forM_ filePaths formatFileWrite
-        when check $ do
-          results <- forM filePaths $ \path -> isWellFormattedFile path <&> (path,)
-          let notFormatted = map fst $ filter (not . snd) results
-          unless (null notFormatted) $ do
-            putStrLn "Some files are not well formatted:"
-            forM_ notFormatted $ \path -> putStrLn ("  " <> path)
-            exitFailure
-          exitSuccess
-
-  Version -> putStrLn (showVersion version)
 
 parseStdin :: IO Rzk.Module
 parseStdin = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2023-09-30
+resolver: nightly-2023-11-19
 packages:
   - rzk

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 402c22fcb980c23c960ce8249d20c572f26abb1395a5d581e71244e7635bc578
-    size: 670169
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/9/30.yaml
-  original: nightly-2023-09-30
+    sha256: a424b2a8716202ff22da255350a0c13cbea24f5e319f80b129a16ee09c1c7ef3
+    size: 698983
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/11/19.yaml
+  original: nightly-2023-11-19


### PR DESCRIPTION
This implements a very basic formatter that scans the lexical tokens for some known patterns and applies text edits to have them adhere to the [style guide](https://rzk-lang.github.io/sHoTT/STYLEGUIDE/). The code is still in an early stage and can definitely be improved a lot, so a code review would be tremendously helpful.

Also, an issue was discovered with LSP's VFS wherein it includes carriage return (`\r`) character on Windows, causing issues with the parser. A workaround has been added (`filter (/= '\r')`), but can probably be improved.

# Notable features
- Adds a space after the opening parenthesis to help with the [code tree structure](https://rzk-lang.github.io/sHoTT/STYLEGUIDE/#the-tree-structure-of-constructions)
- Puts the definition conclusion (type, starting with `:`) and construction (body, starting with `:=`) on new lines
- Adds a space after the `\` of a lambda term and around binary operators (like `,`)
- Moves binary operators to the beginning of the next line if they appear at the end of the previous one.
- Replaces [common ASCII sequences](https://rzk-lang.github.io/sHoTT/STYLEGUIDE/#use-of-unicode-characters) with their Unicode equivalent
- A CLI subcommand (`rzk format`) with `--check` and `--write` options

# Known limitations
- The 80 character line limit is currently not enforced due to the difficulty of determining where to add line breaks (for reference, check out [this post](https://journal.stuffwithstuff.com/2015/09/08/the-hardest-program-ive-ever-written/) by a Dart fmt engineer)
- Fixing indentation is not yet implemented due to the need for more semantics than the lexer provides to determine indentation level.
- ~~Moving binary operators from the end of the line to the beginning of the next is not yet implemented~~. **Edit:** Implemented for `,` and `->`. What other binary operators are needed?
- No commands other than `#define` (and its alias `#def`) are handled yet.
- There are rare edge cases in which applying the formatter twice would result in additional edits that were not detected the first time.

I will open separate issues to work on these in the future.

## Possible inconsistencies in the style guide

These may not be inconsistencies as much as a lack of understand on my side, but I'd like to understand either way:
- About the spaces after opening parenthesis, it seems that 2 styles have been used when it comes to nested parentheses. One example has `( ( a-term-of-a-type) ...)` (with a space after the inner paren), while another is written as `( (x : A) ...)` (without a space before the `x`)
- Regarding the same recommendation about space in opening parentheses, it seems that it only applies when that open paren is the first character in its line. For example, it appears as `: (x = z)` in the type. However, in the sHoTT repo itself, a definition has `: ( concat A w x z p ...)` with a space after the paren. Which one should it be?

# Planned improvements
- Formatting configuration settings (preferably in `rzk.yaml`, but possible also `.vscode/settings.json`) for controlling options like auto-replacement of ASCII sequences, line width,  ...

A pull request to the sHoTT repo (and others) will follow after more work is done into stabilizing the formatter and implementing more rules.