### PR TITLE
Release v0.7.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
   - family-names: Danko
     given-names: Danila
 title: "Rzk: a  proof assistant for synthetic $\\infty$-categories"
-version: 0.7.1
+version: 0.7.2
 url: "https://github.com/rzk-lang/rzk"

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.7.2 — 2023-12-12
+
+Fixes:
+- Fixes for `rzk format`:
+    - Fix extra space after open parens in formatter (see [#155](https://github.com/rzk-lang/rzk/pull/155));
+    - Replace line string content with tokens when checking open parens (see [#156](https://github.com/rzk-lang/rzk/pull/156));
+- Throw an error when `rzk.yaml`'s `include` is empty (see [#154](https://github.com/rzk-lang/rzk/pull/154));
+
+Changes to the Rzk website:
+  - Support multiple languages in the documentation (see [#150](https://github.com/rzk-lang/rzk/pull/150));
+      - English is the default;
+      - Russian documentation is partially translated and is available at <http://rzk-lang.github.io/rzk/ru/>;
+  - Add a blog (see [#153](https://github.com/rzk-lang/rzk/pull/153) and [`e438820`](https://github.com/rzk-lang/rzk/commit/e4388202cea59531903c4c24b939841b2771ceb7));
+      - The blog is not versioned and is always available at <https://rzk-lang.github.io/rzk/en/blog/>;
+  - Add a new [Other proof assistants for HoTT](https://rzk-lang.github.io/rzk/en/v0.7.2/related/) page (also [in Russian](https://rzk-lang.github.io/rzk/ru/v0.7.2/related/));
+  - Add a new [Introduction to Dependent Types](https://rzk-lang.github.io/rzk/en/v0.7.2/getting-started/dependent-types.rzk/) page (also [in Russian](https://rzk-lang.github.io/rzk/ru/v0.7.2/getting-started/dependent-types.rzk/))
+  - Add (default) social cards
+  - Integrate ToC on the left
+  - Use Inria Sans for English, PT Sans for Russian
+
 ## v0.7.1 — 2023-12-08
 
 - Fix default build to include Rzk Language Server (`rzk lsp`) (see [`9b78a15`](https://github.com/rzk-lang/rzk/commit/9b78a15c750699afa93c4dab3735c2aa31e6faac));

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.7.1
+version: 0.7.2
 github: "rzk-lang/rzk"
 license: BSD3
 author: "Nikolai Kudasov"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.7.1
+version:        0.7.2
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types


### PR DESCRIPTION
Fixes:
- Fixes for `rzk format`:
    - Fix extra space after open parens in formatter (see [#155](https://github.com/rzk-lang/rzk/pull/155));
    - Replace line string content with tokens when checking open parens (see [#156](https://github.com/rzk-lang/rzk/pull/156));
- Throw an error when `rzk.yaml`'s `include` is empty (see [#154](https://github.com/rzk-lang/rzk/pull/154));

Changes to the Rzk website:
  - Support multiple languages in the documentation (see [#150](https://github.com/rzk-lang/rzk/pull/150));
      - English is the default;
      - Russian documentation is partially translated and is available at <http://rzk-lang.github.io/rzk/ru/>;
  - Add a blog (see [#153](https://github.com/rzk-lang/rzk/pull/153) and [`e438820`](https://github.com/rzk-lang/rzk/commit/e4388202cea59531903c4c24b939841b2771ceb7));
      - The blog is not versioned and is always available at <https://rzk-lang.github.io/rzk/en/blog/>;
  - Add a new [Other proof assistants for HoTT](https://rzk-lang.github.io/rzk/en/v0.7.2/related/) page (also [in Russian](https://rzk-lang.github.io/rzk/ru/v0.7.2/related/));
  - Add a new [Introduction to Dependent Types](https://rzk-lang.github.io/rzk/en/v0.7.2/getting-started/dependent-types.rzk/) page (also [in Russian](https://rzk-lang.github.io/rzk/ru/v0.7.2/getting-started/dependent-types.rzk/))
  - Add (default) social cards
  - Integrate ToC on the left
  - Use Inria Sans for English, PT Sans for Russian