### PR TITLE
Release v0.7.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
   - family-names: Danko
     given-names: Danila
 title: "Rzk: a  proof assistant for synthetic $\\infty$-categories"
-version: 0.7.2
+version: 0.7.3
 url: "https://github.com/rzk-lang/rzk"

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.7.3 — 2023-12-16
+
+Fixes:
+- Fix overlapping edits in the formatter, hopefully making it idempotent (see [#160](https://github.com/rzk-lang/rzk/pull/160));
+- Fix formatter crashing the language server (see [#161](https://github.com/rzk-lang/rzk/pull/161));
+- Avoid unnecessary typechecking when semantics of a file has not changed (see [#159](https://github.com/rzk-lang/rzk/pull/159));
+- Stop typechecking after the first parse error (avoid invalid cache) (see [`68ab0b4`](https://github.com/rzk-lang/rzk/commit/68ab0b4dd3d627756e10adb55cb16845b08d09d9));
+
+Other:
+- Add unit tests for the formatter (see [#157](https://github.com/rzk-lang/rzk/pull/157));
+
 ## v0.7.2 — 2023-12-12
 
 Fixes:

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -1,5 +1,5 @@
 name: rzk
-version: 0.7.2
+version: 0.7.3
 github: "rzk-lang/rzk"
 license: BSD3
 author: "Nikolai Kudasov"

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           rzk
-version:        0.7.2
+version:        0.7.3
 synopsis:       An experimental proof assistant for synthetic ∞-categories
 description:    Please see the README on GitHub at <https://github.com/rzk-lang/rzk#readme>
 category:       Dependent Types


### PR DESCRIPTION
Fixes:
- Fix overlapping edits in the formatter, hopefully making it idempotent (see [#160](https://github.com/rzk-lang/rzk/pull/160));
- Fix formatter crashing the language server (see [#161](https://github.com/rzk-lang/rzk/pull/161));
- Avoid unnecessary typechecking when semantics of a file has not changed (see [#159](https://github.com/rzk-lang/rzk/pull/159));
- Stop typechecking after the first parse error (avoid invalid cache) (see [`68ab0b4`](https://github.com/rzk-lang/rzk/commit/68ab0b4dd3d627756e10adb55cb16845b08d09d9));

Other:
- Add unit tests for the formatter (see [#157](https://github.com/rzk-lang/rzk/pull/157));