### PR TITLE
Fix skipping to typechecking the next file if the current has an error

### DIFF
--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE TupleSections        #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 module Rzk.TypeCheck where
 
 import           Control.Applicative      ((<|>))


### PR DESCRIPTION
By adding type errors to the cache and check them when confirming if the file has changed