### PR TITLE
Blog hotfix: formatter post

### DIFF
--- a/docs/docs/en/posts/2023-12-24-formatter.rzk.md
+++ b/docs/docs/en/posts/2023-12-24-formatter.rzk.md
@@ -45,9 +45,9 @@ For example, consider the following Rzk code:
 #define id (A : U) (x : A) : A := x
 ```
 which has 11 positions where a new line can be inserted, as shown by these markers:
-```rzk
+```
 #define id (A : U) (x : A) : A := x
---     ^  ^  ^ ^  ^  ^ ^  ^ ^ ^  ^
+       ^  ^  ^ ^  ^  ^ ^  ^ ^ ^  ^
 ```
 This amounts to 2048 combinations that have to be ranked for such a simple line.
 Even the ranking itself is not a straightforward problem to tackle.

--- a/docs/docs/en/posts/2023-12-24-formatter.rzk.md
+++ b/docs/docs/en/posts/2023-12-24-formatter.rzk.md
@@ -40,6 +40,8 @@ inserting a new line somewhere in the line, there are $O(2^n)$ possible choices
 to compare between for inserting line breaks.
 For example, consider the following Rzk code:
 ```rzk
+#lang rzk-1
+
 #define id (A : U) (x : A) : A := x
 ```
 which has 11 positions where a new line can be inserted, as shown by these markers:


### PR DESCRIPTION
Adds the required `#lang rzk-1` preamble and unmarks the duplicate code block as Rzk code (to prevent "duplicate identifier" errors)