### PR TITLE
Fix CI: update all actions

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-12]
 
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧰 Setup Stack
-        uses: freckle/stack-action@v4
+        uses: freckle/stack-action@v5
 
       - name: Tar and strip the binary
         run: |
@@ -53,7 +53,7 @@ jobs:
         shell: bash
 
       - name: Upload rzk binary as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: rzk-bin.tar.gz
           name: rzk-${{ runner.os }}-${{ runner.arch }}.tar.gz
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧰 Setup Stack
-        uses: freckle/stack-action@v4
+        uses: freckle/stack-action@v5
 
       - name: 🔨 Build Haddock Documentation (with Stack)
         run: |
@@ -93,11 +93,11 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 📥 Download rzk
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rzk-${{ runner.os }}-${{ runner.arch }}.tar.gz
 

--- a/.github/workflows/ghcjs.yml
+++ b/.github/workflows/ghcjs.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: ❄️ Install Nix
-        uses: nixbuild/nix-quick-install-action@v25
+        uses: nixbuild/nix-quick-install-action@v27
         with:
           nix_conf: |
             substituters = https://cache.nixos.org/ https://cache.iog.io https://nix-community.cachix.org https://miso-haskell.cachix.org

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -2,7 +2,7 @@ name: MKDocs
 
 on:
   push:
-    branches: [develop,mkdocs-*]
+    branches: [develop, mkdocs-*]
     tags: [v*]
     paths:
       - .github/workflows/mkdocs.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 🧰 Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip" # caching pip dependencies
@@ -38,15 +38,13 @@ jobs:
           chmod: 0755
 
       - name: Check Rzk files for each language
-        run:
-          for lang_dir in $(ls -d docs/docs/*/); do
-            pushd ${lang_dir} && rzk typecheck; popd ;
+        run: for lang_dir in $(ls -d docs/docs/*/); do
+          pushd ${lang_dir} && rzk typecheck; popd ;
           done
 
       - name: Check Rzk formatting for each language
-        run:
-          for lang_dir in $(ls -d docs/docs/*/); do
-            pushd ${lang_dir} && rzk format --check; popd ;
+        run: for lang_dir in $(ls -d docs/docs/*/); do
+          pushd ${lang_dir} && rzk format --check; popd ;
           done
 
       - name: 🔨 Install MkDocs Material and mike

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧰 Setup Stack
-        uses: freckle/stack-action@v4
+        uses: freckle/stack-action@v5
         with:
           fast: false
 
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧰 Setup Stack
-        uses: freckle/stack-action@v4
+        uses: freckle/stack-action@v5
         with:
           fast: false
 


### PR DESCRIPTION
Fix the build by switcing the build to `macos-12` instead of `macos-latest`, since the latter does not have Stack (yet). Thanks to @deemp for the pointer!

Also update all actions.