### PR TITLE
Holes: tolerate point holes in tope positions

### DIFF
--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -51,6 +51,7 @@ extra-source-files:
     test/typecheck/cases/ill-hole-infer.rzk
     test/typecheck/cases/ill-hole-pattern-binder-names.rzk
     test/typecheck/cases/ill-hole-recor-branch.rzk
+    test/typecheck/cases/ill-hole-recor-guard-point.rzk
     test/typecheck/cases/ill-hole-unsolved.rzk
     test/typecheck/cases/ill-implicit.rzk
     test/typecheck/cases/ill-interval-no-totality.rzk
@@ -153,6 +154,7 @@ extra-source-files:
     test/typecheck/cases/ill-hole-infer.expect.yaml
     test/typecheck/cases/ill-hole-pattern-binder-names.expect.yaml
     test/typecheck/cases/ill-hole-recor-branch.expect.yaml
+    test/typecheck/cases/ill-hole-recor-guard-point.expect.yaml
     test/typecheck/cases/ill-hole-unsolved.expect.yaml
     test/typecheck/cases/ill-implicit.expect.yaml
     test/typecheck/cases/ill-interval-no-totality.expect.yaml

--- a/rzk/src/Rzk/TypeCheck.hs
+++ b/rzk/src/Rzk/TypeCheck.hs
@@ -4074,6 +4074,25 @@ inferAs expectedKind term = do
   unifyTypes ty expectedKind kind
   return term'
 
+-- | Infer a cube point — the argument of @≡@ or @≤@. A point in inferring
+-- position is normally elaborated by 'inferAs' @cubeT@, but a bare hole there
+-- would hit 'TypeErrorCannotInferHole' because 'infer' cannot guess the cube.
+-- In lenient (hole-checking) mode that hole is a work in progress, so instead of
+-- rejecting it we record it as a point of an as-yet-unknown cube (a hole whose
+-- type is itself a hole of type @cubeT@, the same shape 'allIntroductionsOf'
+-- uses for a tope point) and carry on. This lets a sketch such as
+-- @recOR((? ≤ ?) ↦ ?, …)@ yield hole hints rather than a hard error.
+inferPoint :: Eq var => Term var -> TypeCheck var (TermT var)
+inferPoint (Hole mname) = do
+  reject <- asks holesAreErrors
+  if reject
+    then issueTypeError (TypeErrorCannotInferHole (Hole mname))
+    else do
+      let cube = HoleT TypeInfo{ infoType = cubeT, infoWHNF = Nothing, infoNF = Nothing } Nothing
+      recordHole mname cube
+      return (HoleT TypeInfo{ infoType = cube, infoWHNF = Nothing, infoNF = Nothing } mname)
+inferPoint term = inferAs cubeT term
+
 infer :: Eq var => Term var -> TypeCheck var (TermT var)
 infer tt = performing (ActionInfer tt) $ case tt of
   Hole _mname -> issueTypeError (TypeErrorCannotInferHole tt)
@@ -4168,17 +4187,21 @@ infer tt = performing (ActionInfer tt) $ case tt of
   TopeBottom -> pure topeBottomT
 
   TopeEQ l r -> do
-    l' <- inferAs cubeT l
+    l' <- inferPoint l
     lt <- typeOf l'
     r' <- typecheck r lt
     return (topeEQT l' r')
 
   TopeLEQ l r -> do
-    l' <- inferAs cubeT l
-    r' <- inferAs cubeT r
+    l' <- inferPoint l
+    r' <- inferPoint r
     lTy <- typeOf l'
     rTy <- typeOf r'
     case (lTy, rTy) of
+      -- An as-yet-unknown cube (a hole left by 'inferPoint' in lenient mode):
+      -- the interval cube cannot be pinned down, so we accept the tope as a
+      -- sketch rather than demanding a concrete 2 or 𝕀.
+      _ | isHoleT lTy || isHoleT rTy -> return (topeLEQT l' r')
       (Cube2T{}, Cube2T{}) -> return (topeLEQT l' r')
       (CubeIT{}, CubeIT{}) -> return (topeLEQT l' r')
       (CubeIT{}, Cube2T{}) -> do

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -115,6 +115,22 @@ spec = do
           map show (holeTopes h2) `shouldContain` ["s ≤ t"]
         hs  -> expectationFailure ("expected exactly two holes, got " <> show (length hs))
 
+    -- A hole in a point position of a tope (the argument of ≤ or ≡) — here the
+    -- recOR branch /guard/ `? ≤ ?`. The point is inferred, so a bare hole would
+    -- hit TypeErrorCannotInferHole; in lenient mode it is instead recorded as a
+    -- point of an as-yet-unknown cube (goal `?`) and the sketch yields hints
+    -- rather than a hard error. The branch body (against A) and the guard's two
+    -- point holes are all recorded.
+    it "records a hole in a recOR branch guard point position" $ do
+      case holesOf "#lang rzk-1\n#define square : (A : U) -> A -> (2 × 2) -> A\n  := \\ A a (t , s) -> recOR ( ? ≤ ? ↦ a , ? ↦ a )\n" of
+        holes -> do
+          -- the two point holes of `? ≤ ?` carry an unknown-cube goal …
+          length (filter ((== "?") . show . holeGoal) holes) `shouldBe` 2
+          -- … the second branch guard `?` is a tope (goal TOPE) …
+          map show (map holeGoal holes) `shouldContain` ["TOPE"]
+          -- … and elaboration as a whole succeeds (no fatal error, holes recorded)
+          length holes `shouldBe` 3
+
     -- When the recOR is checked against an /extension type/, each branch hole
     -- reports the boundary it must meet under its tope (the restriction is
     -- pushed into the branches), rather than the bare underlying type. So the

--- a/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
+++ b/rzk/test/typecheck/PR_TYPECHECK_FIXTURES.md
@@ -7,7 +7,7 @@ Paired `*.rzk` / `*.rzk.md` + `*.expect.yaml` (or dir `expect.yaml`). `Rzk.TypeC
 - **Bad commands/sections/render:** options (`ill-set-option-*`, `ill-unset-option-unknown`), sections (`ill-section-*`), LaTeX define (`ill-render-latex-define`).
 - **UNSAT topes/shapes/`recOR`:** `ill-tope-not-satisfied-*`, `ill-tope-subtle-*`, `ill-rec-or-overlap-incoherent`, `ill-recor-coverage-required`, `ill-restrict-face-disjoint`, `ill-recor-guard-disjoint`, nested `recOR` (`ill-tope-nested-rec-or-inner-singleton`; `*-inner-singleton-d{4,5,6}`) (exhibit exponential slowdown).
 - **recBOT body well-formedness:** `ill-recbot-term-not-function`, `ill-recbot-term-undefined` (ill-typed bodies must not be admitted under an absurd hypothesis).
-- **Holes (strict mode):** `ill-hole-unsolved` (a hole is an error by default), `ill-hole-infer` (a hole in inference position cannot be guessed). The lenient mode and the structured goal/context query are covered by `Rzk.HolesSpec`, not by YAML fixtures.
+- **Holes (strict mode):** `ill-hole-unsolved` (a hole is an error by default), `ill-hole-infer` (a hole in inference position cannot be guessed), `ill-hole-recor-guard-point` (a hole in a tope point position — a recOR branch guard — cannot be guessed either). The lenient mode and the structured goal/context query are covered by `Rzk.HolesSpec`, not by YAML fixtures.
 - **Other layouts:** `multimodule-*`, `literate-fence/`.
 
 # Regression tests
@@ -30,7 +30,7 @@ Fixture comments and `regression_for` use stable prose (which judgment fails, wh
 | Commit ac9b6d89 refl / check | `happy-refl-path` | `refl_{x}` and identity `#check` |
 | Docs: sections / implicit | `ill-implicit` | `TypeErrorImplicitAssumption` |
 | Coverage matrix | `ill-unify`, `ill-undefined`, `ill-duplicate`, `ill-not-function`, `happy-check` | Core `TypeError` constructors |
-| Typed holes (strict mode) | `ill-hole-unsolved`, `ill-hole-infer` | A hole is `TypeErrorUnsolvedHole` by default (finished work/CI reject holes); a hole in inference position is `TypeErrorCannotInferHole`. Lenient mode + structured goal/context in `Rzk.HolesSpec`. |
+| Typed holes (strict mode) | `ill-hole-unsolved`, `ill-hole-infer`, `ill-hole-recor-guard-point` | A hole is `TypeErrorUnsolvedHole` by default (finished work/CI reject holes); a hole in inference position — including a tope point position, e.g. a recOR branch guard — is `TypeErrorCannotInferHole`. Lenient mode + structured goal/context in `Rzk.HolesSpec`. |
 | Pattern-binder name restoration | `ill-hole-pattern-binder-names` | A pair-pattern lambda `\ (a , b) -> ?` renders its components by name in the strict-mode error: the goal `B (first p)` folds to `B a` and the binder shows as `(a , b)`, not `π₁ x` of a fresh variable. Lenient-mode goals/context covered by `Rzk.HolesSpec`. |
 | Bare pattern point in tope | `ill-tope-pattern-binder-bare` | A pattern-bound point used bare (not projected) in a shape's membership tope renders as the pattern: a type error's local tope context shows `Δ² (t , s)`, not `Δ² x₁`. Complements the projection-folding restoration above. |
 

--- a/rzk/test/typecheck/cases/ill-hole-recor-guard-point.expect.yaml
+++ b/rzk/test/typecheck/cases/ill-hole-recor-guard-point.expect.yaml
@@ -1,0 +1,6 @@
+status: error
+error_tag: TypeErrorCannotInferHole
+message_contains:
+  - "cannot infer the type of a hole"
+regression_for:
+  - holes-point-inference-position

--- a/rzk/test/typecheck/cases/ill-hole-recor-guard-point.rzk
+++ b/rzk/test/typecheck/cases/ill-hole-recor-guard-point.rzk
@@ -1,0 +1,11 @@
+#lang rzk-1
+
+-- A hole in a point position of a tope — here the recOR branch /guard/ `? ≤ ?`,
+-- whose points (the arguments of ≤) are in inference position. In the default
+-- (strict) mode the point cannot be guessed, so it is reported rather than
+-- admitted. In lenient (hole-checking) mode the same hole is instead recorded
+-- as a point of an as-yet-unknown cube and the sketch yields hints (see the
+-- "recOR branch guard point position" case in HolesSpec).
+#define square (A : U) (a : A)
+  : (2 × 2) → A
+  := \ (t , s) → recOR ( ? ≤ ? ↦ a , ? ↦ a )


### PR DESCRIPTION
The point arguments of the topes `≡` and `≤` are in inference position. Ordinary inference rejects a bare hole there because its cube cannot be determined. In lenient mode, this made an incomplete `recOR` guard fail before Rzk could report its holes.

For example, consider a guard whose relation is still to be filled in:

```rzk
#define square (A : U) (a : A)
  : (2 × 2) → A
  := \\ (t , s) → recOR (? ≤ ? ↦ a , ? ↦ a)
```

With this change, lenient mode records three holes: the two points of `? ≤ ?`, each with an as-yet-unknown cube, and the second branch guard with goal `TOPE`. The incomplete sketch therefore remains available to the LSP and the game for diagnostics and suggestions.