### PR TITLE
Treat a projection of a hole as hole-headed

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## Unreleased
+
+Fixed:
+
+- **A lemma about projections is offered as a hole candidate** where it was not. A result type headed by a hole is treated as fitting any goal (see [#338](https://github.com/rzk-lang/rzk/pull/338)); a projection applied to a hole now counts the same way, since `#!rzk first ?` is whatever the pair's first component turns out to be and has no shape of its own to mismatch with. Before this, a lemma such as `#!rzk first-path-Σ ... : first s = first t` was offered only when both endpoints matched structurally, and was dropped exactly when it was needed, against a goal with a plain variable at one endpoint.
+
 ## v0.11.2 — 2026-08-20
 
 A maintenance release. Checking no longer stops at the first declaration that fails, errors are reported at the sub-term rather than at the enclosing declaration, and a lemma stated over a motive is offered as a hole candidate, so an eliminator written in the sHoTT style is visible as a move.

--- a/rzk/src/Language/Rzk/Foil/Syntax.hs
+++ b/rzk/src/Language/Rzk/Foil/Syntax.hs
@@ -354,8 +354,8 @@ isHoleT :: TermT n -> Bool
 isHoleT HoleT{} = True
 isHoleT _       = False
 
--- | Is the term a /flexible/ spine: a hole, or an application headed by one
--- (@? a b@)?
+-- | Is the term a /flexible/ spine: a hole, or an elimination headed by one
+-- (@? a b@, @first ?@, @second (? a)@)?
 --
 -- Such a term is not yet committed to any shape: filling the head hole can turn
 -- it into anything. A type of this form therefore stands for an arbitrary type,
@@ -363,10 +363,19 @@ isHoleT _       = False
 -- (@ind-path A a C d x p : C x p@) be judged against a concrete goal. Contrast
 -- 'containsHole', which is also true of a term whose /shape/ is already fixed
 -- and only has holes among its parts (@? = ?@ is an identity type either way).
+--
+-- A projection counts for the same reason an application does. @first ?@ is
+-- whatever the first component of the pair turns out to be, so it has no shape
+-- of its own to mismatch with. Without this, a lemma stating a property of
+-- projections (@first-path-Σ ... : first s = first t@) is not offered against a
+-- goal whose endpoint is a plain variable, because solving @first ?t@ against it
+-- would mean inventing the pair.
 isHoleHeadedT :: TermT n -> Bool
-isHoleHeadedT HoleT{}     = True
-isHoleHeadedT (AppT _ f _) = isHoleHeadedT f
-isHoleHeadedT _           = False
+isHoleHeadedT HoleT{}       = True
+isHoleHeadedT (AppT _ f _)  = isHoleHeadedT f
+isHoleHeadedT (FirstT _ t)  = isHoleHeadedT t
+isHoleHeadedT (SecondT _ t) = isHoleHeadedT t
+isHoleHeadedT _             = False
 
 -- | The name of every hole in a term.
 holeNamesOf :: Term n -> [Maybe VarIdent]

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -468,6 +468,23 @@ spec = do
       in flip oneHole (holesWithLemmas ["ind-path"] indSrc) $ \h ->
            cands h `shouldContain` ["ind-path ? ? ? ? ? ?"]
 
+    -- A projection is flexible for the same reason an application is: @first ?@
+    -- has no shape of its own. Without that, a lemma about projections is
+    -- offered only when both endpoints happen to match structurally, and is
+    -- dropped exactly when the goal needs it, e.g. the first-path-Σ step of the
+    -- Yoneda geodesic, whose goal has a plain variable on the right.
+    it "offers a lemma with a projection endpoint against a rigid endpoint" $
+      let fstSrc = "#lang rzk-1\n"
+                <> "#define fst-path (A : U) (B : A -> U)\n"
+                <> "  (s t : Sigma (a : A) , B a) (e : s = t)\n"
+                <> "  : first s = first t\n"
+                <> "  := idJ (Sigma (a : A) , B a , s ,\n"
+                <> "          \\ t' e' -> first s = first t' , refl , t , e)\n"
+                <> "#define goal (A : U) (B : A -> U)\n"
+                <> "  (w : Sigma (a : A) , B a) (c : A) : first w = c := ?\n"
+      in flip oneHole (holesWithLemmas ["fst-path"] fstSrc) $ \h ->
+           cands h `shouldContain` ["fst-path ? ? ? ? ?"]
+
     -- Fitting anything does not mean escaping the allow-list: a hole-headed
     -- lemma is still only offered when the level grants it.
     it "does not offer a hole-headed lemma that was not allow-listed" $


### PR DESCRIPTION
Closes #342.

```haskell
isHoleHeadedT HoleT{}       = True
isHoleHeadedT (AppT _ f _)  = isHoleHeadedT f
isHoleHeadedT (FirstT _ t)  = isHoleHeadedT t   -- new
isHoleHeadedT (SecondT _ t) = isHoleHeadedT t   -- new
```

A result type headed by a hole fits any goal (#338): filling the head can turn it into anything, so it has no shape to mismatch with. A projection of a hole is flexible for the same reason, `first ?` being whatever the pair's first component turns out to be.

Candidates for `#!rzk fst-path (A : U) (B : A → U) (s t : Σ (a : A) , B a) (e : s = t) : first s = first t`, allow-listed:

| goal | before | after |
| --- | --- | --- |
| `first w = first v` | `fst-path ? ? ? ? ?` | unchanged |
| `first w = c` | `idJ` wrapper only | `fst-path ? ? ? ? ?` |

- the lemma used to be offered only when both endpoints matched structurally, and dropped exactly when the goal needed it
- fitting `first ?t` against a variable would mean inventing the pair, so the whole candidate went
- what survived was an `idJ` transport mentioning the lemma, which a game denying `idJ` filters too, leaving no correct move
- rejecting the unification is right; suppressing the move is not, since a move is a suggestion whose arguments are holes and the term is type-checked once written

Found in the ∞-Yoneda game at the uniqueness of composites step, by an ICERM playtest (https://github.com/rzk-lang/yoneda-game/pull/21): the goal is `comp-is-segal A is-segal-A x y z f g = h` with `h` a variable, and `first-path-Σ` was never offered while three wrong candidates were.