### PR TITLE
Offer the cube's points as introductions

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -10,6 +10,8 @@ and this project adheres to the
 
 Fixed:
 
+- **A hole in a cube position is offered the cube's points.** A hole of type `#!rzk 2` had no introduction forms at all, so writing a corner of a square as `#!rzk α ? ?` left the two obvious fillings, `#!rzk 0₂` and `#!rzk 1₂`, unsuggested. The directed interval and the unit cube now offer their closed points, the way every other goal shape offers its introductions. An in-scope cube variable was already offered as a candidate and is unaffected.
+
 - **A lemma about projections is offered as a hole candidate** where it was not. A result type headed by a hole is treated as fitting any goal (see [#338](https://github.com/rzk-lang/rzk/pull/338)); a projection applied to a hole now counts the same way, since `#!rzk first ?` is whatever the pair's first component turns out to be and has no shape of its own to mismatch with. Before this, a lemma such as `#!rzk first-path-Σ ... : first s = first t` was offered only when both endpoints matched structurally, and was dropped exactly when it was needed, against a goal with a plain variable at one endpoint.
 
 ## v0.11.2 — 2026-08-20

--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -505,6 +505,11 @@ allIntroductionsOf target takenNames = do
       pure [ pairT target' h (mkHole bAt) ]
     CubeProductT _ty a b ->
       pure [ pairT target' (mkHole a) (mkHole b) ]
+    -- the directed interval: its two endpoints are the only closed points, and
+    -- they are what a hole in a cube position (@α ? ?@) almost always wants.
+    -- The unit cube is offered the same way, for its single point.
+    Cube2T{} -> pure [ cube2_0T, cube2_1T ]
+    CubeUnitT{} -> pure [ cubeUnitStarT ]
     TypeIdT _ty a _tA b -> do
       agree <- endpointsAgree a b
       pure [ reflT target' Nothing | agree ]

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -596,6 +596,15 @@ spec = do
         [h] -> intros h `shouldBe` ["\\ n → ?"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A hole in a cube position gets the cube's closed points. Writing a corner
+    -- of a square as `α ? ?` is common, and 0₂ / 1₂ are the only two points of
+    -- the directed interval, so leaving them unoffered left such a hole with no
+    -- introduction at all. An in-scope cube variable is already a candidate.
+    it "introduces a directed-interval goal as its two endpoints" $ do
+      case holesOf "#lang rzk-1\n#define D1 : 2 -> TOPE := \\ t -> TOP\n#define f (A : U) (a : D1 -> A) : A := a ?\n" of
+        [h] -> intros h `shouldBe` ["0₂", "1₂"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- The λ binder is freshened so it does not shadow a name already in scope.
     -- Here the goal unfolds to `(t : 2) -> A`, whose binder `t` (taken from
     -- `endo`'s definition, mirroring `hom`) clashes with the in-scope cube


### PR DESCRIPTION
```
#def goal (A : U) (a : D1 → D1 → A) : A := a ? ?

  hole, goal = 2
    intros:  []        ->  ["0₂", "1₂"]
    cands:   []            []
```

A hole whose goal is the directed interval had no introduction forms, so writing a corner of a square as `α ? ?` left the Moves panel empty at each hole, though `0₂` and `1₂` are the only two closed points there are.

- every other goal shape already offers its introductions: a function a λ, a Σ a pair, the tope universe every tope constructor
- the unit cube gets its single point for the same reason
- an in-scope cube variable was already offered as a candidate and is unaffected

Found while playtesting the ∞-Yoneda game, where a new level states its goal over the corners of a square.