### PR TITLE
Name a candidate's holes after its binders

### DIFF
--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -10,6 +10,8 @@ and this project adheres to the
 
 Fixed:
 
+- **A hole in a cube position is offered the cube's points.** A hole of type `#!rzk 2` had no introduction forms at all, so writing a corner of a square as `#!rzk α ? ?` left the two obvious fillings, `#!rzk 0₂` and `#!rzk 1₂`, unsuggested. The directed interval and the unit cube now offer their closed points, the way every other goal shape offers its introductions. An in-scope cube variable was already offered as a candidate and is unaffected.
+
 - **A lemma about projections is offered as a hole candidate** where it was not. A result type headed by a hole is treated as fitting any goal (see [#338](https://github.com/rzk-lang/rzk/pull/338)); a projection applied to a hole now counts the same way, since `#!rzk first ?` is whatever the pair's first component turns out to be and has no shape of its own to mismatch with. Before this, a lemma such as `#!rzk first-path-Σ ... : first s = first t` was offered only when both endpoints matched structurally, and was dropped exactly when it was needed, against a goal with a plain variable at one endpoint.
 
 ## v0.11.2 — 2026-08-20

--- a/rzk/ChangeLog.md
+++ b/rzk/ChangeLog.md
@@ -8,6 +8,10 @@ and this project adheres to the
 
 ## Unreleased
 
+Added:
+
+- **A suggested move names its holes.** A candidate spine used to render as `#!rzk id-hom ? ?`, giving no clue what each hole stood for, and two spines of the same lemma applied to different numbers of arguments were told apart only by counting. Each hole now carries its Π binder's name, so the same pair reads `#!rzk id-hom ?A ?x` and `#!rzk id-hom ?A ?x ?t`, and the move reads like the lemma's own signature. Named holes were already valid input syntax and are reported by name, so a tapped move keeps its names in the editor.
+
 Fixed:
 
 - **A hole in a cube position is offered the cube's points.** A hole of type `#!rzk 2` had no introduction forms at all, so writing a corner of a square as `#!rzk α ? ?` left the two obvious fillings, `#!rzk 0₂` and `#!rzk 1₂`, unsuggested. The directed interval and the unit cube now offer their closed points, the way every other goal shape offers its introductions. An in-scope cube variable was already offered as a candidate and is unaffected.

--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -103,7 +103,16 @@ checkNameShadowing name =
 
 -- | A fresh hole of the given type.
 mkHole :: TermT n -> TermT n
-mkHole t = HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } Nothing
+mkHole = mkNamedHole Nothing
+
+-- | A hole carrying a name, so a suggested move can say what each of its holes
+-- stands for: @id-hom ?A ?x@ rather than @id-hom ? ?@. The name is the Π
+-- binder's, so the move reads like the lemma's own signature, and two spines of
+-- the same lemma applied to different numbers of arguments are told apart by
+-- what the extra holes are called.
+mkNamedHole :: Maybe VarIdent -> TermT n -> TermT n
+mkNamedHole mname t =
+  HoleT TypeInfo{ infoType = t, infoWHNF = Nothing, infoNF = Nothing } mname
 
 -- | The constructors of a @#data@ type former, in declaration order; empty
 -- for anything else. Found by their roles: the type former itself carries
@@ -316,9 +325,9 @@ eliminatorsOf
   => Set.Set VarIdent -> TermT n -> TypeCheck n [(ElimCost, TermT n -> TypeCheck n (TermT n))]
 eliminatorsOf takenNames ty =
   case stripTypeRestrictions ty of
-    TypeFunT _ty _orig _md param _mtope ret ->
+    TypeFunT _ty orig _md param _mtope ret ->
       pure [ (SpineStep, \term -> do
-                let h = mkHole param
+                let h = mkNamedHole (binderName orig) param
                 retAt <- instantiate ret h
                 pure (appT retAt term h)) ]
     TypeSigmaT _ty _orig _md a b ->

--- a/rzk/src/Rzk/TypeCheck/Judgements.hs
+++ b/rzk/src/Rzk/TypeCheck/Judgements.hs
@@ -505,6 +505,11 @@ allIntroductionsOf target takenNames = do
       pure [ pairT target' h (mkHole bAt) ]
     CubeProductT _ty a b ->
       pure [ pairT target' (mkHole a) (mkHole b) ]
+    -- the directed interval: its two endpoints are the only closed points, and
+    -- they are what a hole in a cube position (@α ? ?@) almost always wants.
+    -- The unit cube is offered the same way, for its single point.
+    Cube2T{} -> pure [ cube2_0T, cube2_1T ]
+    CubeUnitT{} -> pure [ cubeUnitStarT ]
     TypeIdT _ty a _tA b -> do
       agree <- endpointsAgree a b
       pure [ reflT target' Nothing | agree ]

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -440,8 +440,8 @@ spec = do
                  <> "#postulate pick : (X : U) -> (Y : U) -> X -> X\n"
                  <> "#define goal : A -> A := ?\n"
       in flip oneHole (holesWithLemmas ["pick"] metaSrc) $ \h -> do
-           cands h `shouldContain` ["pick ? ?"]
-           filter (`elem` ["pick", "pick ?"]) (cands h) `shouldBe` []
+           cands h `shouldContain` ["pick ?X ?Y"]
+           filter (`elem` ["pick", "pick ?X"]) (cands h) `shouldBe` []
 
     -- Also at the schema's own type: the bare alias is not offered (writing
     -- the alias is the user's call), while the saturated spine still is.
@@ -450,7 +450,7 @@ spec = do
                   <> "#define my-id (X : U) (x : X) : X := x\n"
                   <> "#define goal : (X : U) -> X -> X := ?\n"
       in flip oneHole (holesWithLemmas ["my-id"] aliasSrc) $ \h -> do
-           cands h `shouldContain` ["my-id ?"]
+           cands h `shouldContain` ["my-id ?X"]
            filter (== "my-id") (cands h) `shouldBe` []
 
     -- A lemma whose result type is a motive application (@ind-path ... : C x p@)
@@ -466,7 +466,7 @@ spec = do
                 <> "  := idJ (A , a , C , d , x , p)\n"
                 <> "#define goal (A : U) (x y : A) (p : x = y) : y = x := ?\n"
       in flip oneHole (holesWithLemmas ["ind-path"] indSrc) $ \h ->
-           cands h `shouldContain` ["ind-path ? ? ? ? ? ?"]
+           cands h `shouldContain` ["ind-path ?A ?a ?C ?d ?x ?p"]
 
     -- A projection is flexible for the same reason an application is: @first ?@
     -- has no shape of its own. Without that, a lemma about projections is
@@ -483,7 +483,7 @@ spec = do
                 <> "#define goal (A : U) (B : A -> U)\n"
                 <> "  (w : Sigma (a : A) , B a) (c : A) : first w = c := ?\n"
       in flip oneHole (holesWithLemmas ["fst-path"] fstSrc) $ \h ->
-           cands h `shouldContain` ["fst-path ? ? ? ? ?"]
+           cands h `shouldContain` ["fst-path ?A ?B ?s ?t ?e"]
 
     -- Fitting anything does not mean escaping the allow-list: a hole-headed
     -- lemma is still only offered when the level grants it.

--- a/rzk/test/Rzk/HolesSpec.hs
+++ b/rzk/test/Rzk/HolesSpec.hs
@@ -596,6 +596,15 @@ spec = do
         [h] -> intros h `shouldBe` ["\\ n → ?"]
         hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
 
+    -- A hole in a cube position gets the cube's closed points. Writing a corner
+    -- of a square as `α ? ?` is common, and 0₂ / 1₂ are the only two points of
+    -- the directed interval, so leaving them unoffered left such a hole with no
+    -- introduction at all. An in-scope cube variable is already a candidate.
+    it "introduces a directed-interval goal as its two endpoints" $ do
+      case holesOf "#lang rzk-1\n#define D1 : 2 -> TOPE := \\ t -> TOP\n#define f (A : U) (a : D1 -> A) : A := a ?\n" of
+        [h] -> intros h `shouldBe` ["0₂", "1₂"]
+        hs  -> expectationFailure ("expected exactly one hole, got " <> show (length hs))
+
     -- The λ binder is freshened so it does not shadow a name already in scope.
     -- Here the goal unfolds to `(t : 2) -> A`, whose binder `t` (taken from
     -- `endo`'s definition, mirroring `hom`) clashes with the in-scope cube


### PR DESCRIPTION
```
before                after
  id-hom ? ?            id-hom ?A ?x
  id-hom ? ? ?          id-hom ?A ?x ?t
```

rzk offers a lemma at every number of arguments that fits, so the panel shows the same name applied to more holes and the two are told apart only by counting question marks. Players hit this while playtesting the ∞-Yoneda game and had to work out for themselves that the repetition was about arity.

- each argument hole takes its Π binder's name, so a move reads like the lemma's signature
- the longer spine says at a glance what the extra argument is, here a cube variable
- an anonymous binder (a domain written `B → …`) still yields a bare `?`
- named holes were already valid input syntax and already reported by name, so a tapped move keeps its names in the editor and the hole panel names them