### PR TITLE
Unify: compare lambdas up to their domain shapes

### DIFF
--- a/rzk/src/Rzk/TypeCheck/Unify.hs
+++ b/rzk/src/Rzk/TypeCheck/Unify.hs
@@ -51,6 +51,24 @@ alphaEq l r = do
   scope <- asks ctxScope
   pure (alphaEqT scope l r)
 
+-- | Run @check super sub@ on the pair @(expected, actual)@, oriented by the
+-- ambient variance. Under 'Covariant' the expected type is the supertype and
+-- under 'Contravariant' the actual one is. 'Invariant' is normally handled
+-- upstream by running both directions; we run both here as well, for safety.
+bySubtyping
+  :: (TermT n -> TermT n -> TypeCheck n ())
+  -> TermT n -> TermT n -> TypeCheck n ()
+bySubtyping check expected actual = asks ctxCovariance >>= \case
+  Covariant     -> check expected actual
+  Contravariant -> check actual expected
+  Invariant     -> check expected actual >> check actual expected
+
+-- | The domain of a shape-indexed function is contravariant, so the subtype's
+-- domain tope has to hold wherever the supertype's does. Shared by Π-types
+-- and by the lambdas that inhabit them.
+domainEntails :: Distinct n => TermT n -> TermT n -> TypeCheck n ()
+domainEntails superTope subTope = localTope superTope $ contextEntails subTope
+
 unifyTopes :: Distinct n => TermT n -> TermT n -> TypeCheck n ()
 unifyTopes l r = do
   equiv <- (&&)
@@ -284,14 +302,6 @@ unifyInCurrentContext mterm expected actual = performing action $ do
               switchVariance $  -- unifying in the negative position!
                 unifyTerms cube cube' -- FIXME: unifyCubes
               inScope2 orig' md cube' ret ret' $ \binder retBody retBody' -> do
-                -- The tope checks below are subtyping checks with a fixed direction
-                -- relative to (subtype, supertype). Which side is the subtype
-                -- depends on the ambient variance: under Covariant the actual type
-                -- must be a subtype of the expected one; under Contravariant (inside
-                -- a domain) the roles are reversed. Invariant is normally handled
-                -- upstream by running both directions; it is handled here as well
-                -- for safety.
-                variance <- asks ctxCovariance
                 scope <- asks ctxScope
                 let openTope = fmap (openWith scope (Foil.nameOf binder))
                     mtopeIn = openTope mtope
@@ -304,16 +314,11 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                     -- We DO NOT take the tope context Φ into account!
                     expectedTopeNF <- fromMaybe topeTopT <$> traverse nfT mtopeIn
                     actualTopeNF   <- fromMaybe topeTopT <$> traverse nfT mtopeIn'
-                    let subEntailsSuper subNF superNF = do
+                    let superEntailedBySub superNF subNF = do
                           entails <- [plainTope subNF] `entailM` superNF
                           unless (entails || containsHole subNF || containsHole superNF) $
                             issueTypeError (TypeErrorTopeNotSatisfied [subNF] superNF)
-                    case variance of
-                      Covariant     -> subEntailsSuper actualTopeNF expectedTopeNF
-                      Contravariant -> subEntailsSuper expectedTopeNF actualTopeNF
-                      Invariant     -> do
-                        subEntailsSuper actualTopeNF expectedTopeNF
-                        subEntailsSuper expectedTopeNF actualTopeNF
+                    bySubtyping superEntailedBySub expectedTopeNF actualTopeNF
                   _ -> do
                     -- this is the case for Π-types and extension types
                     --
@@ -321,14 +326,7 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                     -- when Ξ | Φ, ψ ⊢ φ
                     expectedTopeNF <- fromMaybe topeTopT <$> traverse nfT mtopeIn
                     actualTopeNF   <- fromMaybe topeTopT <$> traverse nfT mtopeIn'
-                    let superEntailsSub superNF subNF =
-                          localTope superNF $ contextEntails subNF
-                    case variance of
-                      Covariant     -> superEntailsSub expectedTopeNF actualTopeNF
-                      Contravariant -> superEntailsSub actualTopeNF expectedTopeNF
-                      Invariant     -> do
-                        superEntailsSub expectedTopeNF actualTopeNF
-                        superEntailsSub actualTopeNF expectedTopeNF
+                    bySubtyping domainEntails expectedTopeNF actualTopeNF
                 case mterm of
                   Nothing -> unifyTerms retBody retBody'
                   Just term ->
@@ -385,8 +383,14 @@ unifyInCurrentContext mterm expected actual = performing action $ do
                         let openTope = fmap (openWith scope (Foil.nameOf binder))
                         case (openTope mtope, openTope mtope') of
                           (Just tope, Just tope') -> do
-                            unify Nothing tope tope' -- we (should) have already checked this in types!
-                            localTope tope $ unify Nothing bodyIn bodyIn'
+                            -- The two lambdas need not stand on the same shape.
+                            -- η-expansion takes the domain tope from the
+                            -- function's own type, so this is the same
+                            -- obligation as for the Π-type above.
+                            bySubtyping domainEntails tope tope'
+                            -- The bodies agree only where both are defined.
+                            localTope (topeAndT tope tope') $
+                              unify Nothing bodyIn bodyIn'
                           (Nothing, Nothing) ->
                             unify Nothing bodyIn bodyIn'
                           _ -> errIn


### PR DESCRIPTION
Two lambdas were required to carry *logically equivalent* domain topes. In sHoTT that rejects `eq-dhom-refl-is-locally-contr-extext`, where `f-eq-g-canon` lives on `Δ¹` and is compared against its own η-expansion on `Δ¹ ∧ ∂Δ¹`:

```
expected tope
  ⊤ ∧ (t ≡ 0₂ ∨ t ≡ 1₂)
but got
  ⊤
```

η-expansion takes the domain tope from the function's *own* type, not from the expected type at the use site, so a function defined on a larger shape is met by a lambda restricted to a smaller one. The two topes legitimately differ.

## The rule

The Π-*type* case a few lines up already gets this right: it discharges the domain as a one-directional subtyping obligation, with the direction read off `ctxCovariance`. That is `S-Pi-Shape` as the paper states it,[^paper] where the two domain topes are related by entailment only. The λ-*term* case instead called `unifyTopes`.

The check is now the same obligation as for Π-types, in the same direction. The bodies are compared under the conjunction of the two topes, which is where both functions are defined; under `Covariant` that conjunction *is* the expected tope, so the common path is unchanged.

## Why this went unnoticed

The NbE conversion fast path answers "convertible" before the decomposition gets a chance to invent the false subgoal, so the corpus went through anyway. With the fast path forced off, the pinned sHoTT corpus **fails** to typecheck at the definition above before this change, and passes after it.

That matters beyond this one definition: it means the fast path had been supplying typing power that the declarative rules attribute to subtyping, and that the two are now back in agreement on this corpus. The fast path is once again only a speedup here, which is what it is documented to be.

[^paper]: Nikolai Kudasov, Violetta Sim, and Benedikt Ahrens. *Rzk: a Proof Assistant for Synthetic ∞-Categories.* — `S-Pi-Shape` in the subtyping figure of the declarative-Rzk section, whose degenerate cube premise is kept expressly "to record the intended variance".