### PR TITLE
Free foil 0.4.0

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -56,6 +56,11 @@ jobs:
           ./setup.sh
           ~/.ghc-wasm/add_to_github_path.sh
 
+      - name: 🔄 Refresh the Hackage index
+        # Keep in sync with wasm.yml: a dependency released after setup.sh
+        # fetched its index snapshot is invisible to the solver otherwise.
+        run: wasm32-wasi-cabal update
+
       - name: 💾 Restore cached wasm cabal store
         uses: actions/cache@v4
         with:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -108,5 +108,11 @@ jobs:
           restore-keys: |
             wasm-cabal-${{ runner.os }}-ghc${{ env.FLAVOUR }}-
 
+      - name: 🔄 Refresh the Hackage index
+        # The toolchain cache freezes the index snapshot setup.sh fetched, so
+        # a dependency released since the cache entry was created is invisible
+        # to the solver until the index is refreshed.
+        run: wasm32-wasi-cabal update
+
       - name: 🔨 Build rzk library (LSP off)
         run: wasm32-wasi-cabal build rzk:lib:rzk --flags=-lsp

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,8 +9,8 @@ let
       free-foil = final.callHackageDirect
         {
           pkg = "free-foil";
-          ver = "0.3.2";
-          sha256 = "sha256-B9JccfYo9jSjJ3sPt2fTRM463Qg7qvt7czDU5Vc+utA=";
+          ver = "0.4.0";
+          sha256 = "sha256-6c7BKi9DtC2IeLh55FyEAXTGscbABpTdYia4cdebEtc=";
         }
         { };
       ${rzk} = final.callCabal2nix rzk rzk-src { };

--- a/rzk/package.yaml
+++ b/rzk/package.yaml
@@ -65,7 +65,7 @@ dependencies:
   bytestring: ">= 0.10.8.2 && < 1"
   containers: ">= 0.6 && < 1"
   directory: ">= 1.2.7.0 && < 2"
-  free-foil: ">= 0.3.2 && < 0.4"
+  free-foil: ">= 0.4 && < 0.5"
   # Reads the commit at compile time for `rzk version --full`. Degrades to
   # "UNKNOWN" when there is no git or no repository (a Hackage tarball, the
   # wasm cross-build), so it never breaks a build that cannot run git.

--- a/rzk/rzk.cabal
+++ b/rzk/rzk.cabal
@@ -456,7 +456,7 @@ library
     , bytestring >=0.10.8.2 && <1
     , containers >=0.6 && <1
     , directory >=1.2.7.0 && <2
-    , free-foil >=0.3.2 && <0.4
+    , free-foil ==0.4.*
     , gitrev >=1.3.1 && <2
     , kind-generics >=0.5 && <1
     , kind-generics-th >=0.2 && <1
@@ -510,7 +510,7 @@ executable rzk
     , bytestring >=0.10.8.2 && <1
     , containers >=0.6 && <1
     , directory >=1.2.7.0 && <2
-    , free-foil >=0.3.2 && <0.4
+    , free-foil ==0.4.*
     , gitrev >=1.3.1 && <2
     , kind-generics >=0.5 && <1
     , kind-generics-th >=0.2 && <1
@@ -547,7 +547,7 @@ test-suite doctests
     , containers >=0.6 && <1
     , directory >=1.2.7.0 && <2
     , doctest-parallel >=0.3 && <1
-    , free-foil >=0.3.2 && <0.4
+    , free-foil ==0.4.*
     , gitrev >=1.3.1 && <2
     , kind-generics >=0.5 && <1
     , kind-generics-th >=0.2 && <1
@@ -596,7 +596,7 @@ test-suite rzk-test
     , containers >=0.6 && <1
     , directory >=1.2.7.0 && <2
     , filepath >=1.4 && <2
-    , free-foil >=0.3.2 && <0.4
+    , free-foil ==0.4.*
     , gitrev >=1.3.1 && <2
     , hspec >=2.7 && <3
     , hspec-discover >=2.7 && <3

--- a/rzk/src/Language/Rzk/Foil/Convert.hs
+++ b/rzk/src/Language/Rzk/Foil/Convert.hs
@@ -387,7 +387,7 @@ withOpenTerm term k = go Foil.emptyScope [] Map.empty idents
 
 -- | Sink an association list of binders by coercion, with no per-entry
 -- rebuild ('withOpenTerm' calls this at every binder it opens).
--- 'Foil.sinkContainer' cannot see through the pair (its element must be the
+-- 'Foil.sink1' cannot see through the pair (its element must be the
 -- sunk type itself), but the sinkability argument is the same: only the
 -- names mention the scope, and a name sinks by coercion.
 sinkBound :: Foil.DExt n l => [(VarIdent, Foil.Name n)] -> [(VarIdent, Foil.Name l)]

--- a/rzk/src/Language/Rzk/Foil/Syntax.hs
+++ b/rzk/src/Language/Rzk/Foil/Syntax.hs
@@ -316,9 +316,10 @@ nubT (t : ts) = t : nubT (filter (not . eqT t) ts)
 
 -- | The free variables of a term.
 --
--- free-foil has @freeVarsOf@ only on its unreleased @main@, so this is written
--- here. A name bound on the way down is dropped from the result, which is what
--- makes the coercion back to the outer scope right.
+-- free-foil 0.4.0 exports @freeVarsOf@, but it deduplicates and sorts; this one
+-- keeps mention order and repeats, as the old representation's did. A name
+-- bound on the way down is dropped from the result, which is what makes the
+-- coercion back to the outer scope right.
 freeVarsOfTerm :: Term n -> [Foil.Name n]
 freeVarsOfTerm (Var x)    = [x]
 freeVarsOfTerm (UntypedNode sig) = bifoldMap freeVarsOfScoped freeVarsOfTerm sig

--- a/rzk/src/Rzk/TypeCheck/Context.hs
+++ b/rzk/src/Rzk/TypeCheck/Context.hs
@@ -419,16 +419,16 @@ instance Foil.Sinkable ModalTope where
     tope { tTope = Foil.sinkabilityProof rename (tTope tope) }
 
 sinkVars :: DExt n l => NameMap n (VarInfo n) -> NameMap n (VarInfo l)
-sinkVars = Foil.sinkContainer
+sinkVars = Foil.sink1
 
 sinkTopes :: DExt n l => [ModalTope n] -> [ModalTope l]
-sinkTopes = Foil.sinkContainer
+sinkTopes = Foil.sink1
 
 sinkNamed :: DExt n l => Map VarIdent (Foil.Name n) -> Map VarIdent (Foil.Name l)
-sinkNamed = Foil.sinkContainer
+sinkNamed = Foil.sink1
 
 sinkNames :: DExt n l => [Foil.Name n] -> [Foil.Name l]
-sinkNames = Foil.sinkContainer
+sinkNames = Foil.sink1
 
 -- * Lookup
 

--- a/rzk/src/Rzk/TypeCheck/Decl.hs
+++ b/rzk/src/Rzk/TypeCheck/Decl.hs
@@ -86,9 +86,9 @@ sinkDecl = Foil.sink
 
 -- | Sinking a whole list is a coercion too, with no per-element rebuild.
 sinkDecls :: DExt n l => [Decl n] -> [Decl l]
-sinkDecls = Foil.sinkContainer
+sinkDecls = Foil.sink1
 
--- | The per-file groups also sink by coercion. 'Foil.sinkContainer' cannot
+-- | The per-file groups also sink by coercion. 'Foil.sink1' cannot
 -- see through the pair (its element must be the sunk type itself), but the
 -- sinkability argument is the same: only the declarations mention the scope.
 sinkDeclGroups :: DExt n l => [(FilePath, [Decl n])] -> [(FilePath, [Decl l])]
@@ -147,9 +147,9 @@ withTopLevel name ty mval isAssumption usedVars mrole k = do
           { declName = name
           , declNameOf = Foil.nameOf binder
           , declType = Foil.sink ty
-          , declValue = Foil.sinkContainer mval
+          , declValue = Foil.sink1 mval
           , declIsAssumption = isAssumption
-          , declUsedVars = Foil.sinkContainer usedVars
+          , declUsedVars = Foil.sink1 usedVars
           , declLocation = ctxLocation ctx
           }
     inContext ctx' (k binder decl)
@@ -695,7 +695,7 @@ withDataDecls path used name paramVars paramDecls sortIndices consData elims k =
   dDeps <- assumptionDepsOf dTy
   withTopLevel (varIdentAt path name) dTy Nothing False
     (nubNames (used <> dDeps)) Nothing $ \dBinder dDecl ->
-      bindCons (Foil.nameOf dBinder) (Foil.sinkContainer used) 0 consData [sinkDecl dDecl] $
+      bindCons (Foil.nameOf dBinder) (Foil.sink1 used) 0 consData [sinkDecl dDecl] $
         \dName usedL declsAcc -> bindElims dName usedL declsAcc
   where
     numParams  = length paramDecls
@@ -750,7 +750,7 @@ withDataDecls path used name paramVars paramDecls sortIndices consData elims k =
               (map fst (dataConRecursive con)))
       withTopLevel (varIdentAt path (dataConName con)) conTy Nothing False
         (nubNames (usedHere <> conDeps)) (Just role) $ \_conBinder conDecl ->
-          bindCons (Foil.sink dName) (Foil.sinkContainer usedHere) (index + 1) rest
+          bindCons (Foil.sink dName) (Foil.sink1 usedHere) (index + 1) rest
             (sinkDecls acc <> [conDecl]) kk
 
     bindElims
@@ -885,12 +885,12 @@ withDataDecls path used name paramVars paramDecls sortIndices consData elims k =
           recCanonical <- memoizeWHNF =<< typecheck recTyT universeT
           recTy' <- reascribe recName recCanonical mrecTy
           recDeps <- assumptionDepsOf recTy'
-          let usedAtInd = Foil.sinkContainer usedHere
+          let usedAtInd = Foil.sink1 usedHere
           withTopLevel (varIdentAt path recName) recTy' Nothing False
             (nubNames (usedAtInd <> recDeps))
             (Just (DataRole (Foil.sink dName) numParams (DataElimKind numMethods indexArity ElimRec))) $ \_ recDecl ->
               bindComputes
-                (Foil.sinkContainer usedAtInd)
+                (Foil.sink1 usedAtInd)
                 computeReasc
                 (computeRules et)
                 (sinkDecls (sinkDecls declsAcc <> [indDecl]) <> [recDecl])
@@ -912,7 +912,7 @@ withDataDecls path used name paramVars paramDecls sortIndices consData elims k =
       deps <- assumptionDepsOf ty'
       withTopLevel (varIdentAt path cname) ty' Nothing False
         (nubNames (usedHere <> deps)) Nothing $ \_ decl ->
-          bindComputes (Foil.sinkContainer usedHere) reasc rest
+          bindComputes (Foil.sink1 usedHere) reasc rest
             (sinkDecls acc <> [decl])
 
     -- | Split the re-ascription clauses among the generated entries: the

--- a/rzk/src/Rzk/TypeCheck/Render.hs
+++ b/rzk/src/Rzk/TypeCheck/Render.hs
@@ -332,7 +332,7 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
               ret' <- openScoped binder ret
               -- FIXME: breaks for 2 * (2 * 2), but works for 2 * 2 * 2 = (2 * 2) * 2
               Just <$> renderForSubShapeSVG mainColor dim
-                (Foil.sinkContainer xs) (Foil.nameOf binder)
+                (Foil.sink1 xs) (Foil.nameOf binder)
                 ret' (Foil.sink f) (Foil.sink x)
       _ -> do
         t' <- whnfT t
@@ -351,8 +351,8 @@ renderTermSVGFor mainColor accDim (mp, xs) t = do
             pure (appT ret' (Foil.sink t') z)
         let mp' | extend = join' (fmap (both Foil.sink) mp) arg' z
                 | otherwise = fmap (both Foil.sink) mp
-            xs' | extend = Foil.nameOf binder : Foil.sinkContainer xs
-                | otherwise = Foil.sinkContainer xs
+            xs' | extend = Foil.nameOf binder : Foil.sink1 xs
+                | otherwise = Foil.sink1 xs
         renderTermSVGFor mainColor accDim' (mp', xs') body
 
     both f (x, y) = (f x, f y)

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,9 +2,9 @@ resolver: lts-24.34
 packages:
   - rzk
 
-# Not in the snapshot: free-foil 0.3.2 (its ZipMatchK TH deriver, explicit
-# annotated ZipMatchK, and sinkContainer are what the core relies on) and the
-# kind-generics deriving it needs.
+# Not in the snapshot: free-foil 0.4.0 (its ZipMatchK TH deriver, explicit
+# annotated ZipMatchK, and the O(1) sink family are what the core relies on)
+# and the kind-generics deriving it needs.
 extra-deps:
-  - free-foil-0.3.2
+  - free-foil-0.4.0
   - kind-generics-th-0.2.3.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: free-foil-0.3.2@sha256:cec5ff659a0214561bc7d5dc056137d1451d84e7133c658868e7f0ee1d762ee4,5491
+    hackage: free-foil-0.4.0@sha256:4cfd40e7ae9bc0b65e299adb71d67e68a34ebf5e2d05a2f8dd95f70864c8a072,7717
     pantry-tree:
-      sha256: b1ee9f798f887f203d6ca2255f7813366d8c8b1cd05c11794baac0aad8767f1e
-      size: 3081
+      sha256: 009de37e1cbabd5869cf38851c2004d7f34805d06594af3e6707ddf4c6ecebbc
+      size: 4324
   original:
-    hackage: free-foil-0.3.2
+    hackage: free-foil-0.4.0
 - completed:
     hackage: kind-generics-th-0.2.3.3@sha256:c53280116db0dab9891f5a531679073f0b1f9ba6b8a3399bca11d98c506d0c62,1578
     pantry-tree:


### PR DESCRIPTION
This PR moves rzk from free-foil 0.3.2 to free-foil 0.4.0 and picks up its performance improvements. On the full sHoTT corpus (bench harness, median of 3 runs, same machine):

| | free-foil 0.3.2 | free-foil 0.4.0 | change |
|---|---|---|---|
| wall clock | 1.646 s | 1.577 s | −4.2 % |
| allocation | 10.66 GB | 10.32 GB | −3.2 % |
| max residency | 526 MB | 419 MB | −20.3 % |

The wins come from upstream, with no code changes on our side. Most notably:
- `substitute` short-circuits the empty substitution,
- the binder and substitution operations are `INLINABLE` so call sites specialise through them.

The residency drop is the most visible effect on sHoTT.

Two things were tried and deliberately not kept:

- `INLINABLE` on the scope helpers (`withScopedT`, `openWith`, `inScope`, `openScoped`);
- Upstream's newly released `freeVarsOf`, which deduplicates and sorts; rzk keeps its own mention-order variant, and the comment now says why.

`withRefreshedIn` and the reservation/stripe machinery are for the module-system work, not this PR.